### PR TITLE
make index token all synchronous

### DIFF
--- a/internal/workflows/index_owner_wf.go
+++ b/internal/workflows/index_owner_wf.go
@@ -1219,7 +1219,7 @@ func (w *workerCore) indexTokenChunk(ctx workflow.Context, tokenCIDs []domain.To
 	}
 
 	indexTokensWorkflowOptions := workflow.ChildWorkflowOptions{
-		WorkflowExecutionTimeout: time.Hour,
+		WorkflowExecutionTimeout: 2 * time.Hour,
 	}
 	indexTokensCtx := workflow.WithChildOptions(ctx, indexTokensWorkflowOptions)
 


### PR DESCRIPTION
# Pull Request

## Description

This PR adds backpressure to token indexing to prevent the system from being flooded by fire-and-forget metadata/provenance workflows when many owners are indexed concurrently. `IndexToken` now waits for metadata (and full provenance when applicable) to complete before finishing, and the `IndexTokens` child workflow timeout is increased to accommodate the longer per-token work.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Related Issues

<!-- Link to related issues -->
Fixes #
Related to #

## Changes Made

- Make `IndexToken` wait for `IndexTokenMetadata` and `IndexTokenProvenances` child workflows (best-effort: failures are logged but not propagated).
- Change metadata/provenance child workflow `ParentClosePolicy` to `REQUEST_CANCEL` to avoid orphaned work when the parent is canceled.
- Increase `IndexTokens` child workflow execution timeout from 1h to 2h (owner indexing path).

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

### Test Steps

1. Run `gofmt -w internal/workflows/index_owner_wf.go internal/workflows/index_token_wf.go`
2. Run `go test ./...`
3. Run `golangci-lint run --path-mode=abs`

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- This intentionally adds backpressure: overall indexing may take longer, but it reduces queue flooding and improves fairness for newly-triggered owner indexing runs.
- Metadata/provenance failures do not fail the token/owner workflow; they are logged as warnings.
