### PR TITLE
Add local media provider and dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ go.work.sum
 **/.env.local
 config/.env.media.local
 config/.env.worker-media.local
+config/.env
+
+# Local media artifacts
+tmp/
 
 # Config files (keep samples only)
 config.yaml

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -165,6 +165,21 @@ cd cmd/worker-media
 go run main.go
 ```
 
+Local media provider (default) writes files to `./tmp/media` and serves them via a small static server:
+- Config: `media.provider=local`, `media.local.storage_dir`, `media.local.base_url`
+- Static server: `media.local.server.enabled=true` (default `http://localhost:8082/media`)
+- Cloudflare remains available by setting `media.provider=cloudflare` and Cloudflare credentials
+
+To enqueue a local media indexing job (data URI or URL), use the media CLI:
+```bash
+go run cmd/media-cli/main.go
+
+# Or pass a specific URL or data URI
+go run cmd/media-cli/main.go -url "https://placehold.co/1x1.jpg"
+```
+
+If PNG data URIs fail with `vipspng` errors, your libvips build likely lacks PNG loaders. The default CLI sample uses JPEG to avoid that.
+
 ### Data URI Media Processing
 
 When metadata contains data URIs, the media worker decodes and transforms them server-side before upload:

--- a/cmd/media-cli/main.go
+++ b/cmd/media-cli/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"strings"
+	"time"
+
+	"go.temporal.io/sdk/client"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/feral-file/ff-indexer-v2/internal/config"
+	"github.com/feral-file/ff-indexer-v2/internal/logger"
+)
+
+var (
+	configFile = flag.String("config", "", "Path to configuration file")
+	envPath    = flag.String("env", "config/", "Path to environment files")
+	urlFlag    = flag.String("url", "", "Media URL or data URI to index")
+	urlsFlag   = flag.String("urls", "", "Comma-separated list of media URLs/data URIs")
+)
+
+func main() {
+	flag.Parse()
+
+	config.ChdirRepoRoot()
+	cfg, err := config.LoadWorkerMediaConfig(*configFile, *envPath)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to load config: %v", err))
+	}
+
+	if err := logger.Initialize(logger.Config{Debug: cfg.Debug, BreadcrumbLevel: zapcore.InfoLevel}); err != nil {
+		panic(fmt.Sprintf("Failed to initialize logger: %v", err))
+	}
+	defer logger.Flush(2 * time.Second)
+
+	ctx := context.Background()
+
+	urls := parseURLs(*urlFlag, *urlsFlag)
+	if len(urls) == 0 {
+		urls = []string{sampleDataURI()}
+	}
+
+	clientOptions := client.Options{
+		HostPort:  cfg.Temporal.HostPort,
+		Namespace: cfg.Temporal.Namespace,
+	}
+	temporalClient, err := client.Dial(clientOptions)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to connect to Temporal: %v", err))
+	}
+	defer temporalClient.Close()
+
+	if len(urls) == 1 {
+		workflowID := fmt.Sprintf("media-cli-%d", time.Now().UnixNano())
+		workflowOptions := client.StartWorkflowOptions{
+			ID:        workflowID,
+			TaskQueue: cfg.Temporal.MediaTaskQueue,
+		}
+
+		we, err := temporalClient.ExecuteWorkflow(ctx, workflowOptions, "IndexMediaWorkflow", urls[0])
+		if err != nil {
+			panic(fmt.Sprintf("Failed to start workflow: %v", err))
+		}
+
+		fmt.Printf("Started workflow %s (run %s) for URL: %s\n", we.GetID(), we.GetRunID(), urls[0])
+		return
+	}
+
+	workflowID := fmt.Sprintf("media-cli-batch-%d", time.Now().UnixNano())
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        workflowID,
+		TaskQueue: cfg.Temporal.MediaTaskQueue,
+	}
+
+	we, err := temporalClient.ExecuteWorkflow(ctx, workflowOptions, "IndexMultipleMediaWorkflow", urls)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to start workflow: %v", err))
+	}
+
+	fmt.Printf("Started workflow %s (run %s) for %d URLs\n", we.GetID(), we.GetRunID(), len(urls))
+}
+
+func sampleDataURI() string {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{R: 0, G: 0, B: 0, A: 255})
+
+	var buf bytes.Buffer
+	_ = jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return "data:image/jpeg;base64," + encoded
+}
+
+func parseURLs(single string, multiple string) []string {
+	if strings.TrimSpace(multiple) != "" {
+		parts := strings.Split(multiple, ",")
+		urls := make([]string, 0, len(parts))
+		for _, part := range parts {
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" {
+				urls = append(urls, trimmed)
+			}
+		}
+		return urls
+	}
+
+	if strings.TrimSpace(single) != "" {
+		return []string{strings.TrimSpace(single)}
+	}
+
+	return nil
+}

--- a/cmd/media-cli/main.go
+++ b/cmd/media-cli/main.go
@@ -100,7 +100,7 @@ func sampleDataURI() string {
 
 func parseURLs(single string, multiple string) []string {
 	if strings.TrimSpace(multiple) != "" {
-		parts := strings.Split(multiple, ",")
+		parts := splitURLList(multiple)
 		urls := make([]string, 0, len(parts))
 		for _, part := range parts {
 			trimmed := strings.TrimSpace(part)
@@ -116,4 +116,31 @@ func parseURLs(single string, multiple string) []string {
 	}
 
 	return nil
+}
+
+func splitURLList(input string) []string {
+	var parts []string
+	var current strings.Builder
+	input = strings.TrimSpace(input)
+	for i := 0; i < len(input); i++ {
+		if input[i] == ',' {
+			remainder := strings.TrimSpace(input[i+1:])
+			if isURLListDelimiter(remainder) {
+				parts = append(parts, current.String())
+				current.Reset()
+				continue
+			}
+		}
+		current.WriteByte(input[i])
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
+}
+
+func isURLListDelimiter(remainder string) bool {
+	return strings.HasPrefix(remainder, "https://") ||
+		strings.HasPrefix(remainder, "http://") ||
+		strings.HasPrefix(remainder, "data:")
 }

--- a/cmd/media-cli/main_test.go
+++ b/cmd/media-cli/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURLs_UsesSingleValue(t *testing.T) {
+	urls := parseURLs("  https://example.com/a.png  ", "")
+	require.Equal(t, []string{"https://example.com/a.png"}, urls)
+}
+
+func TestParseURLs_MultipleURLsIncludingDataURI(t *testing.T) {
+	input := "https://example.com/a.png, data:image/png;base64,AAAA,https://example.com/b.png"
+	urls := parseURLs("", input)
+	require.Equal(t, []string{
+		"https://example.com/a.png",
+		"data:image/png;base64,AAAA",
+		"https://example.com/b.png",
+	}, urls)
+}
+
+func TestParseURLs_EmptyInput(t *testing.T) {
+	urls := parseURLs("", "   ")
+	require.Nil(t, urls)
+}

--- a/cmd/worker-media/config.yaml.sample
+++ b/cmd/worker-media/config.yaml.sample
@@ -40,6 +40,17 @@ cloudflare:
   account_id: ""
   api_token: ""
 
+media:
+  provider: local # local | cloudflare
+  local:
+    storage_dir: ./tmp/media
+    base_url: http://localhost:8082/media
+    server:
+      enabled: true
+      host: 0.0.0.0
+      port: 8082
+      base_path: /media
+
 # SVG Rasterizer Configuration
 rasterizer:
   width: 2048      # Target width for SVG rasterization (height auto-calculated with best fit, 0 = use SVG natural size)
@@ -63,4 +74,3 @@ transform:
 
 max_image_size: 10485760      # 10MB
 max_video_size: 314572800     # 300MB
-

--- a/cmd/worker-media/main.go
+++ b/cmd/worker-media/main.go
@@ -4,10 +4,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
+	"path"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,11 +28,14 @@ import (
 	"github.com/feral-file/ff-indexer-v2/internal/downloader"
 	"github.com/feral-file/ff-indexer-v2/internal/logger"
 	"github.com/feral-file/ff-indexer-v2/internal/media/processor"
+	mediaprovider "github.com/feral-file/ff-indexer-v2/internal/media/provider"
 	"github.com/feral-file/ff-indexer-v2/internal/media/rasterizer"
 	"github.com/feral-file/ff-indexer-v2/internal/media/transformer"
 	"github.com/feral-file/ff-indexer-v2/internal/providers/cloudflare"
+	"github.com/feral-file/ff-indexer-v2/internal/providers/local"
 	temporal "github.com/feral-file/ff-indexer-v2/internal/providers/temporal"
 	"github.com/feral-file/ff-indexer-v2/internal/store"
+	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
 	"github.com/feral-file/ff-indexer-v2/internal/uri"
 	workflowsmedia "github.com/feral-file/ff-indexer-v2/internal/workflows/media"
 )
@@ -85,6 +92,15 @@ func main() {
 	// Initialize store
 	dataStore := store.NewPGStore(db)
 
+	if strings.ToLower(cfg.Media.Provider) == local.LOCAL_PROVIDER_NAME {
+		exists, err := dataStore.CheckStorageProviderEnum(ctx, schema.StorageProviderLocal)
+		if err != nil {
+			logger.WarnCtx(ctx, "Failed to check storage provider enum", zap.Error(err))
+		} else if !exists {
+			logger.WarnCtx(ctx, "Storage provider enum missing; run migration 013.sql", zap.String("provider", string(schema.StorageProviderLocal)))
+		}
+	}
+
 	// Initialize adapters
 	ioAdapter := adapter.NewIO()
 	jsonAdapter := adapter.NewJSON()
@@ -105,26 +121,41 @@ func main() {
 	}
 	uriResolver := uri.NewResolver(httpClient, uriResolverConfig)
 
-	// Initialize Cloudflare client
-	cfClient, err := adapter.NewCloudflareClient(cfg.Cloudflare.APIToken)
-	if err != nil {
-		logger.FatalCtx(ctx, "Failed to create Cloudflare client", zap.Error(err))
-	}
-
 	// Initialize downloader for media file downloads
 	mediaDownloaderHTTPClient := adapter.NewHTTPClient(15 * time.Minute)
 	mediaDownloader := downloader.NewDownloader(mediaDownloaderHTTPClient, fileSystem)
 
-	// Initialize Cloudflare media provider (handles both Images and Stream)
-	cloudflareConfig := &cloudflare.Config{
-		AccountID: cfg.Cloudflare.AccountID,
-		APIToken:  cfg.Cloudflare.APIToken,
-	}
-	mediaProvider := cloudflare.NewMediaProvider(cfClient, cloudflareConfig, mediaDownloader, fileSystem)
+	// Initialize media provider
+	var mediaProvider mediaprovider.Provider
+	switch strings.ToLower(cfg.Media.Provider) {
+	case local.LOCAL_PROVIDER_NAME:
+		mediaProvider = local.NewMediaProvider(&local.Config{
+			StorageDir: cfg.Media.Local.StorageDir,
+			BaseURL:    cfg.Media.Local.BaseURL,
+		}, mediaDownloader, fileSystem)
 
-	logger.InfoCtx(ctx, "Initialized Cloudflare media provider",
-		zap.String("accountID", cfg.Cloudflare.AccountID),
-	)
+		logger.InfoCtx(ctx, "Initialized local media provider",
+			zap.String("storageDir", cfg.Media.Local.StorageDir),
+			zap.String("baseURL", cfg.Media.Local.BaseURL),
+		)
+	case cloudflare.CLOUDFLARE_PROVIDER_NAME:
+		cfClient, err := adapter.NewCloudflareClient(cfg.Cloudflare.APIToken)
+		if err != nil {
+			logger.FatalCtx(ctx, "Failed to create Cloudflare client", zap.Error(err))
+		}
+
+		cloudflareConfig := &cloudflare.Config{
+			AccountID: cfg.Cloudflare.AccountID,
+			APIToken:  cfg.Cloudflare.APIToken,
+		}
+		mediaProvider = cloudflare.NewMediaProvider(cfClient, cloudflareConfig, mediaDownloader, fileSystem)
+
+		logger.InfoCtx(ctx, "Initialized Cloudflare media provider",
+			zap.String("accountID", cfg.Cloudflare.AccountID),
+		)
+	default:
+		logger.FatalCtx(ctx, "Unsupported media provider", zap.String("provider", cfg.Media.Provider))
+	}
 
 	// Initialize SVG rasterizer with adapters and config
 	browserRasterizer := rasterizer.NewBrowserRasterizer(
@@ -203,6 +234,16 @@ func main() {
 	temporalWorker.RegisterActivity(mediaExecutor.IndexMediaFile)
 	logger.InfoCtx(ctx, "Registered media processing activity")
 
+	// Start local media server (optional)
+	var localMediaServer *http.Server
+	if strings.ToLower(cfg.Media.Provider) == local.LOCAL_PROVIDER_NAME && cfg.Media.Local.Server.Enabled {
+		server, err := startLocalMediaServer(ctx, cfg.Media.Local)
+		if err != nil {
+			logger.FatalCtx(ctx, "Failed to start local media server", zap.Error(err))
+		}
+		localMediaServer = server
+	}
+
 	// Start the worker
 	err = temporalWorker.Start()
 	if err != nil {
@@ -228,5 +269,62 @@ func main() {
 		logger.ErrorCtx(ctx, err, zap.String("component", "transformer"))
 	}
 
+	if localMediaServer != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := localMediaServer.Shutdown(shutdownCtx); err != nil {
+			logger.WarnCtx(ctx, "Failed to stop local media server", zap.Error(err))
+		}
+		shutdownCancel()
+	}
+
 	logger.InfoCtx(ctx, "Worker Media stopped")
+}
+
+func startLocalMediaServer(ctx context.Context, cfg config.LocalMediaConfig) (*http.Server, error) {
+	storageDir := strings.TrimSpace(cfg.StorageDir)
+	if storageDir == "" {
+		return nil, fmt.Errorf("media.local.storage_dir is required")
+	}
+
+	basePath := strings.TrimSpace(cfg.Server.BasePath)
+	if basePath == "" {
+		basePath = "/media"
+	}
+	if !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+
+	host := cfg.Server.Host
+	if host == "" {
+		host = "0.0.0.0"
+	}
+	addr := fmt.Sprintf("%s:%d", host, cfg.Server.Port)
+
+	fileHandler := http.FileServer(http.Dir(storageDir))
+	stripPrefix := path.Clean(basePath)
+
+	mux := http.NewServeMux()
+	mux.Handle(basePath+"/", http.StripPrefix(stripPrefix, fileHandler))
+	mux.Handle(basePath, http.StripPrefix(stripPrefix, fileHandler))
+
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	go func() {
+		logger.InfoCtx(ctx, "Starting local media server",
+			zap.String("addr", addr),
+			zap.String("basePath", basePath),
+			zap.String("storageDir", storageDir),
+		)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.ErrorCtx(ctx, err, zap.String("component", "local-media-server"))
+		}
+	}()
+
+	return server, nil
 }

--- a/db/init_pg_db.sql
+++ b/db/init_pg_db.sql
@@ -7,7 +7,7 @@ CREATE TYPE token_standard AS ENUM ('erc721', 'erc1155', 'fa2');
 CREATE TYPE blockchain_chain AS ENUM ('eip155:1', 'eip155:11155111', 'tezos:mainnet', 'tezos:ghostnet');
 CREATE TYPE enrichment_level AS ENUM ('none', 'vendor');
 CREATE TYPE vendor_type AS ENUM ('artblocks', 'fxhash', 'foundation', 'superrare', 'feralfile', 'objkt', 'opensea');
-CREATE TYPE storage_provider AS ENUM ('self_hosted', 'cloudflare', 's3');
+CREATE TYPE storage_provider AS ENUM ('self_hosted', 'cloudflare', 'local', 's3');
 CREATE TYPE event_type AS ENUM ('mint', 'transfer', 'burn', 'metadata_update');
 CREATE TYPE webhook_delivery_status AS ENUM ('pending', 'success', 'failed');
 CREATE TYPE indexing_job_status AS ENUM ('running', 'paused', 'failed', 'completed', 'canceled');

--- a/db/migrations/016.sql
+++ b/db/migrations/016.sql
@@ -1,0 +1,3 @@
+-- Migration 016: Add local storage provider enum value
+
+ALTER TYPE storage_provider ADD VALUE IF NOT EXISTS 'local';

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,16 +279,38 @@ type TransformConfig struct {
 	WorkerConcurrency int `mapstructure:"worker_concurrency"`
 }
 
+// LocalMediaServerConfig holds configuration for the local media server.
+type LocalMediaServerConfig struct {
+	Enabled  bool   `mapstructure:"enabled"`
+	Host     string `mapstructure:"host"`
+	Port     int    `mapstructure:"port"`
+	BasePath string `mapstructure:"base_path"`
+}
+
+// LocalMediaConfig holds configuration for local media provider.
+type LocalMediaConfig struct {
+	StorageDir string                 `mapstructure:"storage_dir"`
+	BaseURL    string                 `mapstructure:"base_url"`
+	Server     LocalMediaServerConfig `mapstructure:"server"`
+}
+
+// MediaProviderConfig holds configuration for media provider selection.
+type MediaProviderConfig struct {
+	Provider string           `mapstructure:"provider"`
+	Local    LocalMediaConfig `mapstructure:"local"`
+}
+
 type WorkerMediaConfig struct {
 	BaseConfig   `mapstructure:",squash"`
-	Database     DatabaseConfig   `mapstructure:"database"`
-	Temporal     TemporalConfig   `mapstructure:"temporal"`
-	URI          URIConfig        `mapstructure:"uri"`
-	Cloudflare   CloudflareConfig `mapstructure:"cloudflare"`
-	Rasterizer   RasterizerConfig `mapstructure:"rasterizer"`
-	Transform    TransformConfig  `mapstructure:"transform"`
-	MaxImageSize int64            `mapstructure:"max_image_size"`
-	MaxVideoSize int64            `mapstructure:"max_video_size"`
+	Database     DatabaseConfig      `mapstructure:"database"`
+	Temporal     TemporalConfig      `mapstructure:"temporal"`
+	URI          URIConfig           `mapstructure:"uri"`
+	Cloudflare   CloudflareConfig    `mapstructure:"cloudflare"`
+	Media        MediaProviderConfig `mapstructure:"media"`
+	Rasterizer   RasterizerConfig    `mapstructure:"rasterizer"`
+	Transform    TransformConfig     `mapstructure:"transform"`
+	MaxImageSize int64               `mapstructure:"max_image_size"`
+	MaxVideoSize int64               `mapstructure:"max_video_size"`
 }
 
 // MediaHealthSweeperConfig holds configuration for the media health sweeper
@@ -535,6 +557,14 @@ func LoadWorkerMediaConfig(configFile string, envPath string) (*WorkerMediaConfi
 	v.SetDefault("rasterizer.browser_fallback_enabled", false)
 	v.SetDefault("max_image_size", 10*1024*1024)  // 10MB
 	v.SetDefault("max_video_size", 300*1024*1024) // 300MB
+	// Media provider defaults
+	v.SetDefault("media.provider", "local")
+	v.SetDefault("media.local.storage_dir", "./tmp/media")
+	v.SetDefault("media.local.base_url", "http://localhost:8082/media")
+	v.SetDefault("media.local.server.enabled", true)
+	v.SetDefault("media.local.server.host", "0.0.0.0")
+	v.SetDefault("media.local.server.port", 8082)
+	v.SetDefault("media.local.server.base_path", "/media")
 
 	// Transform defaults (90% of max for safety margin)
 	v.SetDefault("transform.target_image_size", int64(float64(10*1024*1024)*0.9)) // 9MB
@@ -776,6 +806,14 @@ func bindAllEnvVars(v *viper.Viper) {
 		"transform.max_decoded_pixels",
 		"transform.transform_timeout",
 		"transform.worker_concurrency",
+		// Media provider
+		"media.provider",
+		"media.local.storage_dir",
+		"media.local.base_url",
+		"media.local.server.enabled",
+		"media.local.server.host",
+		"media.local.server.port",
+		"media.local.server.base_path",
 	}
 
 	for _, key := range commonKeys {

--- a/internal/media/processor/processor.go
+++ b/internal/media/processor/processor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/feral-file/ff-indexer-v2/internal/media/rasterizer"
 	"github.com/feral-file/ff-indexer-v2/internal/media/transformer"
 	"github.com/feral-file/ff-indexer-v2/internal/providers/cloudflare"
+	"github.com/feral-file/ff-indexer-v2/internal/providers/local"
 	"github.com/feral-file/ff-indexer-v2/internal/store"
 	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
 	"github.com/feral-file/ff-indexer-v2/internal/types"
@@ -525,6 +526,8 @@ func (p *processor) toSchemaStorageProvider() schema.StorageProvider {
 	switch p.provider.Name() {
 	case cloudflare.CLOUDFLARE_PROVIDER_NAME:
 		return schema.StorageProviderCloudflare
+	case local.LOCAL_PROVIDER_NAME:
+		return schema.StorageProviderLocal
 	default:
 		return schema.StorageProviderSelfHosted
 	}

--- a/internal/media/processor/processor_test.go
+++ b/internal/media/processor/processor_test.go
@@ -125,3 +125,68 @@ func TestProcess_DataURIImage(t *testing.T) {
 	err := proc.Process(ctx, testDataURIPNG)
 	require.NoError(t, err)
 }
+
+func TestProcess_DataURIImage_LocalProvider(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	jsonAdapter := adapter.NewJSON()
+
+	httpClient := mocks.NewMockHTTPClient(ctrl)
+	uriResolver := mocks.NewMockURIResolver(ctrl)
+	dataChecker := mocks.NewMockDataURIChecker(ctrl)
+	st := mocks.NewMockStore(ctrl)
+	raster := mocks.NewMockRasterizer(ctrl)
+	fs := mocks.NewMockFileSystem(ctrl)
+	ioAdapter := mocks.NewMockIO(ctrl)
+	dl := mocks.NewMockDownloader(ctrl)
+	trans := mocks.NewMockTransformer(ctrl)
+	provider := mocks.NewMockMediaProvider(ctrl)
+
+	provider.EXPECT().Name().Return("local").AnyTimes()
+
+	dataChecker.EXPECT().
+		Check(testDataURIPNG).
+		Return(uri.DataURICheckResult{Valid: true, MimeType: "image/png", DeclaredMimeType: "image/png"})
+
+	trans.EXPECT().
+		Transform(gomock.Any(), gomock.Any()).
+		Return(&transformer.TransformResult{Data: []byte("webp"), ContentType: "image/webp", Filename: "image.webp"}, nil)
+
+	provider.EXPECT().
+		UploadImageFromReader(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&mediaprovider.UploadResult{
+			ProviderAssetID: "asset-123",
+			VariantURLs: map[string]string{
+				"original": "http://localhost/media/asset-123",
+			},
+			ProviderMetadata: map[string]interface{}{"provider": "local"},
+		}, nil)
+
+	st.EXPECT().
+		CreateMediaAsset(ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input store.CreateMediaAssetInput) (*schema.MediaAsset, error) {
+			require.Equal(t, schema.StorageProviderLocal, input.Provider)
+			return &schema.MediaAsset{ID: 1}, nil
+		})
+
+	proc := processor.NewProcessor(
+		httpClient,
+		uriResolver,
+		dataChecker,
+		provider,
+		st,
+		raster,
+		fs,
+		ioAdapter,
+		jsonAdapter,
+		dl,
+		trans,
+		10*1024*1024,
+		10*1024*1024,
+	)
+
+	err := proc.Process(ctx, testDataURIPNG)
+	require.NoError(t, err)
+}

--- a/internal/mocks/store.go
+++ b/internal/mocks/store.go
@@ -9,11 +9,10 @@ import (
 	reflect "reflect"
 	time "time"
 
-	gomock "github.com/golang/mock/gomock"
-
 	domain "github.com/feral-file/ff-indexer-v2/internal/domain"
 	store "github.com/feral-file/ff-indexer-v2/internal/store"
 	schema "github.com/feral-file/ff-indexer-v2/internal/store/schema"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockStore is a mock of Store interface.
@@ -52,6 +51,21 @@ func (m *MockStore) BatchUpdateTokensViewability(ctx context.Context, tokenIDs [
 func (mr *MockStoreMockRecorder) BatchUpdateTokensViewability(ctx, tokenIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchUpdateTokensViewability", reflect.TypeOf((*MockStore)(nil).BatchUpdateTokensViewability), ctx, tokenIDs)
+}
+
+// CheckStorageProviderEnum mocks base method.
+func (m *MockStore) CheckStorageProviderEnum(ctx context.Context, provider schema.StorageProvider) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckStorageProviderEnum", ctx, provider)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckStorageProviderEnum indicates an expected call of CheckStorageProviderEnum.
+func (mr *MockStoreMockRecorder) CheckStorageProviderEnum(ctx, provider interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckStorageProviderEnum", reflect.TypeOf((*MockStore)(nil).CheckStorageProviderEnum), ctx, provider)
 }
 
 // CreateAddressIndexingJob mocks base method.

--- a/internal/providers/local/media_provider.go
+++ b/internal/providers/local/media_provider.go
@@ -101,7 +101,7 @@ func (p *mediaProvider) storeFromReader(ctx context.Context, reader io.Reader, f
 		}
 	}
 
-	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+	if err := os.MkdirAll(storageDir, 0o750); err != nil {
 		return nil, fmt.Errorf("failed to create storage directory: %w", err)
 	}
 

--- a/internal/providers/local/media_provider.go
+++ b/internal/providers/local/media_provider.go
@@ -1,0 +1,216 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gabriel-vasile/mimetype"
+	"go.uber.org/zap"
+
+	"github.com/feral-file/ff-indexer-v2/internal/adapter"
+	"github.com/feral-file/ff-indexer-v2/internal/downloader"
+	"github.com/feral-file/ff-indexer-v2/internal/logger"
+	mediaprovider "github.com/feral-file/ff-indexer-v2/internal/media/provider"
+	"github.com/feral-file/ff-indexer-v2/internal/types"
+)
+
+const LOCAL_PROVIDER_NAME = "local"
+
+// Config holds configuration for local media storage.
+type Config struct {
+	StorageDir string
+	BaseURL    string
+}
+
+type mediaProvider struct {
+	config     *Config
+	downloader downloader.Downloader
+	fs         adapter.FileSystem
+}
+
+// NewMediaProvider creates a new local media provider.
+func NewMediaProvider(config *Config, dl downloader.Downloader, fs adapter.FileSystem) mediaprovider.Provider {
+	return &mediaProvider{
+		config:     config,
+		downloader: dl,
+		fs:         fs,
+	}
+}
+
+// UploadImageFromURL downloads an image and stores it locally.
+func (p *mediaProvider) UploadImageFromURL(ctx context.Context, sourceURL string, metadata map[string]interface{}) (*mediaprovider.UploadResult, error) {
+	result, err := p.downloader.Download(ctx, sourceURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download image: %w", err)
+	}
+	defer func() {
+		if err := result.Close(); err != nil {
+			logger.WarnCtx(ctx, "failed to close download result", zap.Error(err))
+		}
+	}()
+
+	filename := filenameFromURL(sourceURL)
+	return p.storeFromReader(ctx, result.Reader(), filename, result.ContentType(), "image", metadata)
+}
+
+// UploadImageFromReader stores image bytes locally.
+func (p *mediaProvider) UploadImageFromReader(ctx context.Context, reader io.Reader, filename, contentType string, metadata map[string]interface{}) (*mediaprovider.UploadResult, error) {
+	return p.storeFromReader(ctx, reader, filename, contentType, "image", metadata)
+}
+
+// UploadVideo downloads a video and stores it locally.
+func (p *mediaProvider) UploadVideo(ctx context.Context, sourceURL string, metadata map[string]interface{}) (*mediaprovider.UploadResult, error) {
+	result, err := p.downloader.Download(ctx, sourceURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download video: %w", err)
+	}
+	defer func() {
+		if err := result.Close(); err != nil {
+			logger.WarnCtx(ctx, "failed to close download result", zap.Error(err))
+		}
+	}()
+
+	filename := filenameFromURL(sourceURL)
+	return p.storeFromReader(ctx, result.Reader(), filename, result.ContentType(), "video", metadata)
+}
+
+// Name returns the provider name.
+func (p *mediaProvider) Name() string {
+	return LOCAL_PROVIDER_NAME
+}
+
+func (p *mediaProvider) storeFromReader(ctx context.Context, reader io.Reader, filename, contentType, mediaType string, metadata map[string]interface{}) (*mediaprovider.UploadResult, error) {
+	if p.config == nil {
+		return nil, fmt.Errorf("local provider config is required")
+	}
+	storageDir := strings.TrimSpace(p.config.StorageDir)
+	if storageDir == "" {
+		return nil, fmt.Errorf("local provider storage directory is required")
+	}
+
+	if !filepath.IsAbs(storageDir) {
+		abs, err := filepath.Abs(storageDir)
+		if err == nil {
+			storageDir = abs
+		}
+	}
+
+	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	finalName := buildFilename(filename, contentType)
+	path := filepath.Join(storageDir, finalName)
+
+	file, err := p.fs.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local media file: %w", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.WarnCtx(ctx, "failed to close local media file", zap.Error(err))
+		}
+	}()
+
+	written, err := io.Copy(file, reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write local media file: %w", err)
+	}
+
+	variantURL := buildVariantURL(p.config.BaseURL, path, finalName)
+
+	providerMetadata := map[string]interface{}{
+		"storage_path": path,
+		"file_name":    finalName,
+		"content_type": contentType,
+		"size_bytes":   written,
+		"media_type":   mediaType,
+		"created_at":   time.Now().Format(time.RFC3339),
+	}
+	if p.config.BaseURL != "" {
+		providerMetadata["base_url"] = p.config.BaseURL
+	}
+
+	logger.InfoCtx(ctx, "Stored media locally",
+		zap.String("path", path),
+		zap.Int64("bytes", written),
+		zap.String("mediaType", mediaType),
+	)
+
+	return &mediaprovider.UploadResult{
+		ProviderAssetID:  finalName,
+		VariantURLs:      map[string]string{"original": variantURL},
+		ProviderMetadata: providerMetadata,
+	}, nil
+}
+
+func buildFilename(filename, contentType string) string {
+	base := filepath.Base(strings.TrimSpace(filename))
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		base = "media"
+	}
+	base = strings.ReplaceAll(base, " ", "_")
+
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	if ext == "" {
+		ext = fileExtFromMimeType(contentType)
+	}
+
+	suffix, err := types.GenerateSecureToken(6)
+	if err != nil {
+		suffix = fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+
+	return fmt.Sprintf("%s-%s%s", name, suffix, ext)
+}
+
+func buildVariantURL(baseURL, storagePath, filename string) string {
+	if strings.TrimSpace(baseURL) == "" {
+		return storagePath
+	}
+
+	trimmed := strings.TrimRight(baseURL, "/")
+	return trimmed + "/" + url.PathEscape(filename)
+}
+
+func filenameFromURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "media"
+	}
+	base := filepath.Base(parsed.Path)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return "media"
+	}
+	return base
+}
+
+func fileExtFromMimeType(mimeType string) string {
+	if mimeType == "" {
+		return ""
+	}
+	lookup := mimetype.Lookup(mimeType)
+	if lookup != nil {
+		ext := lookup.Extension()
+		if ext != "" {
+			return ext
+		}
+	}
+
+	mainType := strings.Split(mimeType, ";")[0]
+	mainType = strings.TrimSpace(mainType)
+	if strings.HasPrefix(mainType, "video/") {
+		return ".mp4"
+	}
+	if strings.HasPrefix(mainType, "image/") {
+		return ".jpg"
+	}
+	return ""
+}

--- a/internal/providers/local/media_provider_test.go
+++ b/internal/providers/local/media_provider_test.go
@@ -3,14 +3,19 @@ package local_test
 import (
 	"bytes"
 	"context"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/feral-file/ff-indexer-v2/internal/adapter"
+	"github.com/feral-file/ff-indexer-v2/internal/downloader"
 	"github.com/feral-file/ff-indexer-v2/internal/logger"
 	"github.com/feral-file/ff-indexer-v2/internal/providers/local"
 )
@@ -39,11 +44,88 @@ func TestUploadImageFromReader_LocalProvider(t *testing.T) {
 
 	metadata, ok := result.ProviderMetadata["storage_path"].(string)
 	require.True(t, ok)
+	expectedPath := filepath.Join(storageDir, result.ProviderAssetID)
+	require.Equal(t, expectedPath, metadata)
 
-	content, err := os.ReadFile(metadata)
+	content, err := fs.ReadFile(os.DirFS(storageDir), result.ProviderAssetID)
 	require.NoError(t, err)
 	require.Equal(t, data, content)
 
 	require.True(t, strings.HasPrefix(metadata, storageDir))
 	require.Equal(t, filepath.Base(metadata), result.ProviderAssetID)
+}
+
+func TestUploadImageFromReader_RequiresStorageDir(t *testing.T) {
+	ctx := context.Background()
+
+	provider := local.NewMediaProvider(&local.Config{}, nil, adapter.NewFileSystem())
+	_, err := provider.UploadImageFromReader(ctx, bytes.NewReader([]byte("x")), "image", "image/png", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage directory is required")
+}
+
+func TestUploadImageFromReader_EmptyBaseURLUsesStoragePath(t *testing.T) {
+	ctx := context.Background()
+
+	storageDir := t.TempDir()
+	provider := local.NewMediaProvider(&local.Config{
+		StorageDir: storageDir,
+	}, nil, adapter.NewFileSystem())
+
+	result, err := provider.UploadImageFromReader(ctx, bytes.NewReader([]byte("hello")), "generated-name", "image/png", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	storagePath, ok := result.ProviderMetadata["storage_path"].(string)
+	require.True(t, ok)
+	require.Equal(t, storagePath, result.VariantURLs["original"])
+	require.True(t, strings.HasSuffix(result.ProviderAssetID, ".png"))
+}
+
+func TestUploadImageFromURL_LocalProvider(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("png-bytes"))
+	}))
+	t.Cleanup(server.Close)
+
+	storageDir := t.TempDir()
+	dl := downloader.NewDownloader(adapter.NewHTTPClient(5*time.Second), adapter.NewFileSystem())
+	provider := local.NewMediaProvider(&local.Config{StorageDir: storageDir}, dl, adapter.NewFileSystem())
+
+	result, err := provider.UploadImageFromURL(ctx, server.URL+"/images/source.png", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	storagePath, ok := result.ProviderMetadata["storage_path"].(string)
+	require.True(t, ok)
+	content, err := fs.ReadFile(os.DirFS(storageDir), result.ProviderAssetID)
+	require.NoError(t, err)
+	require.Equal(t, []byte("png-bytes"), content)
+	require.Equal(t, storagePath, result.VariantURLs["original"])
+}
+
+func TestUploadVideo_LocalProvider(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "video/mp4")
+		_, _ = w.Write([]byte("mp4-bytes"))
+	}))
+	t.Cleanup(server.Close)
+
+	storageDir := t.TempDir()
+	dl := downloader.NewDownloader(adapter.NewHTTPClient(5*time.Second), adapter.NewFileSystem())
+	provider := local.NewMediaProvider(&local.Config{StorageDir: storageDir}, dl, adapter.NewFileSystem())
+
+	result, err := provider.UploadVideo(ctx, server.URL+"/videos/source.mp4", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	content, err := fs.ReadFile(os.DirFS(storageDir), result.ProviderAssetID)
+	require.NoError(t, err)
+	require.Equal(t, []byte("mp4-bytes"), content)
+	require.True(t, strings.HasSuffix(result.ProviderAssetID, ".mp4"))
 }

--- a/internal/providers/local/media_provider_test.go
+++ b/internal/providers/local/media_provider_test.go
@@ -1,0 +1,49 @@
+package local_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/feral-file/ff-indexer-v2/internal/adapter"
+	"github.com/feral-file/ff-indexer-v2/internal/logger"
+	"github.com/feral-file/ff-indexer-v2/internal/providers/local"
+)
+
+func init() {
+	_ = logger.Initialize(logger.Config{Debug: true})
+}
+
+func TestUploadImageFromReader_LocalProvider(t *testing.T) {
+	ctx := context.Background()
+
+	storageDir := t.TempDir()
+	provider := local.NewMediaProvider(&local.Config{
+		StorageDir: storageDir,
+		BaseURL:    "http://localhost:8082/media",
+	}, nil, adapter.NewFileSystem())
+
+	data := []byte("test-image-bytes")
+	result, err := provider.UploadImageFromReader(ctx, bytes.NewReader(data), "image.png", "image/png", map[string]interface{}{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.ProviderAssetID)
+
+	url := result.VariantURLs["original"]
+	require.True(t, strings.HasPrefix(url, "http://localhost:8082/media/"))
+
+	metadata, ok := result.ProviderMetadata["storage_path"].(string)
+	require.True(t, ok)
+
+	content, err := os.ReadFile(metadata)
+	require.NoError(t, err)
+	require.Equal(t, data, content)
+
+	require.True(t, strings.HasPrefix(metadata, storageDir))
+	require.Equal(t, filepath.Base(metadata), result.ProviderAssetID)
+}

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -792,6 +792,28 @@ func (s *pgStore) GetTokenOwnerProvenancesBulk(ctx context.Context, tokenIDs []u
 	return result, totals, nil
 }
 
+// CheckStorageProviderEnum returns true if the storage_provider enum contains the value.
+func (s *pgStore) CheckStorageProviderEnum(ctx context.Context, provider schema.StorageProvider) (bool, error) {
+	if provider == "" {
+		return false, fmt.Errorf("storage provider cannot be empty")
+	}
+
+	var exists bool
+	err := s.db.WithContext(ctx).
+		Raw(`SELECT EXISTS (
+			SELECT 1
+			FROM pg_enum e
+			JOIN pg_type t ON t.oid = e.enumtypid
+			WHERE t.typname = 'storage_provider'
+			AND e.enumlabel = ?
+		)`, string(provider)).
+		Scan(&exists).Error
+	if err != nil {
+		return false, fmt.Errorf("failed to check storage provider enum: %w", err)
+	}
+	return exists, nil
+}
+
 // GetTokenProvenanceEvents retrieves provenance events for a token
 func (s *pgStore) GetTokenProvenanceEvents(ctx context.Context, tokenID uint64, limit int, offset uint64, orderDesc bool) ([]schema.ProvenanceEvent, uint64, error) {
 	query := s.db.WithContext(ctx).Model(&schema.ProvenanceEvent{}).Where("token_id = ?", tokenID)

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -15,6 +15,8 @@ import (
 	pgdriver "gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+
+	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
 )
 
 var (
@@ -188,4 +190,21 @@ func TestPostgreSQLStore(t *testing.T) {
 	}
 
 	RunStoreTests(t, initPGTestDB, cleanupPGTestDB)
+}
+
+func TestCheckStorageProviderEnum(t *testing.T) {
+	ctx := context.Background()
+	st := initPGTestDB(t)
+
+	exists, err := st.CheckStorageProviderEnum(ctx, schema.StorageProviderLocal)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = st.CheckStorageProviderEnum(ctx, schema.StorageProvider("does_not_exist"))
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	exists, err = st.CheckStorageProviderEnum(ctx, "")
+	require.Error(t, err)
+	require.False(t, exists)
 }

--- a/internal/store/schema/media_asset.go
+++ b/internal/store/schema/media_asset.go
@@ -19,6 +19,8 @@ const (
 	StorageProviderSelfHosted StorageProvider = "self_hosted"
 	// StorageProviderCloudflare represents Cloudflare storage
 	StorageProviderCloudflare StorageProvider = "cloudflare"
+	// StorageProviderLocal represents local storage
+	StorageProviderLocal StorageProvider = "local"
 	// StorageProviderS3 represents S3-compatible storage
 	StorageProviderS3 StorageProvider = "s3"
 )

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -342,6 +342,9 @@ type Store interface {
 	// Returns a map of tokenID -> provenances and a map of tokenID -> total count. Limit is applied per token.
 	GetTokenOwnerProvenancesBulk(ctx context.Context, tokenIDs []uint64, ownerAddresses []string, maxPerToken int) (map[uint64][]schema.TokenOwnershipProvenance, map[uint64]uint64, error)
 
+	// CheckStorageProviderEnum verifies the storage provider enum contains a value
+	CheckStorageProviderEnum(ctx context.Context, provider schema.StorageProvider) (bool, error)
+
 	// =============================================================================
 	// Provenance & Event Tracking
 	// =============================================================================

--- a/internal/workflows/media/executor.go
+++ b/internal/workflows/media/executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/feral-file/ff-indexer-v2/internal/logger"
 	mediaprocessor "github.com/feral-file/ff-indexer-v2/internal/media/processor"
 	"github.com/feral-file/ff-indexer-v2/internal/providers/cloudflare"
+	"github.com/feral-file/ff-indexer-v2/internal/providers/local"
 	"github.com/feral-file/ff-indexer-v2/internal/store"
 	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
 	"github.com/feral-file/ff-indexer-v2/internal/types"
@@ -84,6 +85,8 @@ func (e *executor) toSchemaStorageProvider() schema.StorageProvider {
 	switch e.mediaProcessor.Provider() {
 	case cloudflare.CLOUDFLARE_PROVIDER_NAME:
 		return schema.StorageProviderCloudflare
+	case local.LOCAL_PROVIDER_NAME:
+		return schema.StorageProviderLocal
 	default:
 		return schema.StorageProviderSelfHosted
 	}

--- a/internal/workflows/media/executor_test.go
+++ b/internal/workflows/media/executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/feral-file/ff-indexer-v2/internal/logger"
 	"github.com/feral-file/ff-indexer-v2/internal/mocks"
 	"github.com/feral-file/ff-indexer-v2/internal/providers/cloudflare"
+	"github.com/feral-file/ff-indexer-v2/internal/providers/local"
 	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
 	workflowsmedia "github.com/feral-file/ff-indexer-v2/internal/workflows/media"
 )
@@ -302,6 +303,30 @@ func TestIndexMediaFile_ProviderSelfHosted(t *testing.T) {
 		Return(nil, nil)
 
 	// Mock mediaProcessor.Process to succeed
+	mocks.mediaProcessor.EXPECT().
+		Process(ctx, url).
+		Return(nil)
+
+	err := mocks.executor.IndexMediaFile(ctx, url)
+
+	assert.NoError(t, err)
+}
+
+func TestIndexMediaFile_ProviderLocal(t *testing.T) {
+	mocks := setupTestExecutor(t)
+	defer tearDownTestExecutor(mocks)
+
+	ctx := context.Background()
+	url := "https://example.com/image.png"
+
+	mocks.mediaProcessor.EXPECT().
+		Provider().
+		Return(local.LOCAL_PROVIDER_NAME)
+
+	mocks.store.EXPECT().
+		GetMediaAssetBySourceURL(ctx, url, schema.StorageProviderLocal).
+		Return(nil, nil)
+
 	mocks.mediaProcessor.EXPECT().
 		Process(ctx, url).
 		Return(nil)


### PR DESCRIPTION
## Summary
- add a local media provider with filesystem storage and optional static server for dev
- introduce media provider config + local CLI helper for enqueueing media indexing
- update storage provider enum and docs to support local workflow

## Testing
- `go test ./internal/providers/local/...`