### PR TITLE
docs: align README verification with CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,9 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.golangci.yaml'
+      - '.golangci.strict.yaml'
       - 'Makefile'
+      - 'tools/scripts/post_implementation_check.sh'
       - 'db/**'
       - 'internal/api/graphql/**'
       - '.github/workflows/**'
@@ -19,7 +21,9 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.golangci.yaml'
+      - '.golangci.strict.yaml'
       - 'Makefile'
+      - 'tools/scripts/post_implementation_check.sh'
       - 'db/**'
       - 'internal/api/graphql/**'
       - '.github/workflows/**'
@@ -58,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.5'
+          go-version: '1.24.13'
           cache: true
           cache-dependency-path: ./go.sum
 
@@ -71,7 +75,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4.0
+          version: v2.5.0
           working-directory: ./
 
       - name: Run go fmt check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,9 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.golangci.yaml'
+      - '.golangci.strict.yaml'
       - 'Makefile'
+      - 'tools/scripts/post_implementation_check.sh'
       - 'db/**'
       - 'internal/api/graphql/**'
       - '.github/workflows/**'
@@ -20,7 +22,9 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.golangci.yaml'
+      - '.golangci.strict.yaml'
       - 'Makefile'
+      - 'tools/scripts/post_implementation_check.sh'
       - 'db/**'
       - 'internal/api/graphql/**'
       - '.github/workflows/**'
@@ -76,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.5'
+          go-version: '1.24.13'
           cache: true
           cache-dependency-path: ./go.sum
 
@@ -95,8 +99,8 @@ jobs:
         env:
           PGPASSWORD: postgres
 
-      - name: Run tests with coverage
-        run: go test -v -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -vE "/internal/mocks|/internal/adapter|cmd|internal/store/schema|tools")
+      - name: Run CI-aligned verification
+        run: make post-implementation-check
         env:
           TEST_DB_HOST: localhost
           TEST_DB_PORT: 5432
@@ -104,13 +108,6 @@ jobs:
           TEST_DB_PASSWORD: postgres
           TEST_DB_NAME: test_db
           FF_INDEXER_VENDORS_OPENSEA_API_KEY: ${{ secrets.OPENSEA_TEST_API_KEY }}
-
-      - name: Filter generated files from coverage
-        run: |
-          if [ -f coverage.out ]; then
-            grep -v "generated.go" coverage.out > coverage.filtered.out || true
-            mv coverage.filtered.out coverage.out
-          fi
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ go fmt ./...
 go vet ./...
 
 # Check for common issues
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.1.6 golangci-lint run --verbose
+docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.5.0 golangci-lint run --verbose
 ```
 
 ### Building

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ health: ## Check health status of all services
 lint: ## Run linters in Docker (CGO files skipped - use lint-local for full check)
 	@echo "$(COLOR_BLUE)Running linters in Docker...$(COLOR_RESET)"
 	@echo "$(COLOR_YELLOW)Note: CGO files are skipped in Docker$(COLOR_RESET)"
-	@docker run --rm -v "$(PWD):/app" -w /app -e CGO_ENABLED=0 golangci/golangci-lint:v2.1.6 golangci-lint run --verbose
+	@docker run --rm -v "$(PWD):/app" -w /app -e CGO_ENABLED=0 golangci/golangci-lint:v2.5.0 golangci-lint run --verbose
 	@echo "$(COLOR_GREEN)✓ Linters passed$(COLOR_RESET)"
 
 lint-local: ## Run linters locally with full CGO support (requires libvips: brew install vips)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ cd cmd/sweeper && go run main.go
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed local development setup.
 
+## Verification
+
+Use the repo-wide CI-shaped verification path before handing off substantive changes:
+
+```bash
+make post-implementation-check
+```
+
+This target runs `tools/scripts/post_implementation_check.sh`, which is the same non-mutating verification path used by the GitHub Actions Test workflow. It checks changed Go files for formatting and strict lint issues, then runs the CI test package set with coverage output and generated-file filtering.
+
+`make post-implementation-check` expects PostgreSQL test dependencies at `localhost:5432` by default, matching CI. Start them locally with `make dev`, or override `TEST_DB_HOST`, `TEST_DB_PORT`, `TEST_DB_USER`, `TEST_DB_PASSWORD`, and `TEST_DB_NAME`.
+
+Use `make check` only when you intentionally want the broader local maintenance pass. It runs `imports`, `lint-local`, and `test`; `imports` rewrites Go imports, so it is not the non-mutating CI-shaped verification command.
+
+## GitHub Actions
+
+This repo has these primary GitHub Actions workflows:
+
+- **Test** (`.github/workflows/test.yaml`) - sets up Go 1.24.13, libvips, and PostgreSQL, then runs `make post-implementation-check` and uploads coverage to Codecov.
+- **Lint** (`.github/workflows/lint.yaml`) - runs repo-wide `golangci-lint` v2.5.0 and a `gofmt` check with Go 1.24.13.
+- **Build Images** (`.github/workflows/build-images.yaml`) - builds and publishes container images.
+- **Secret Scan** (`.github/workflows/secret-scan.yaml`) - scans for leaked secrets.
+
 ## Documentation
 
 - **[Agent Guide](AGENTS.md)** - Repository workflow, canonical verification, and PR/review contract for agents and contributors


### PR DESCRIPTION
## Problem

Fixes https://github.com/feral-file/ffos-user/issues/162. The README did not expose the existing repo-wide `make post-implementation-check` path, and GitHub Actions still used Go 1.23.5 even though `go.mod` and the README require Go 1.24+. Lint version references were also split across CI, Makefile, and contributor docs.

## Why it matters

Contributors and agents need one accurate local verification command that matches CI as closely as practical. Keeping CI on an older Go version also makes failures harder to reason about because CI is not using the repository toolchain baseline.

## Acceptance checks

- README documents `make post-implementation-check` as the repo-wide CI-shaped local verification path and clarifies when `make check` is appropriate.
- Test workflow uses Go 1.24.13 and calls `make post-implementation-check` instead of duplicating the test and coverage commands inline.
- Lint workflow, Makefile, and contributor docs consistently use `golangci-lint` v2.5.0.

## Validation run

- `make post-implementation-check` started and confirmed no changed Go files relative to `origin/main`; it then blocked because PostgreSQL was not reachable at `localhost:5432`.
- Attempted to start a temporary PostgreSQL container, but Docker daemon was not running: `Cannot connect to the Docker daemon at unix:///Users/anhnguyen/.docker/run/docker.sock`.
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/test.yaml .github/workflows/lint.yaml .github/workflows/build-images.yaml .github/workflows/secret-scan.yaml` passed.
- `git diff --check` passed.
- `go list ./... | grep -vE '/internal/mocks|/internal/adapter|cmd|internal/store/schema|tools' | wc -l` returned 40 packages.