### PR TITLE
feat(media): opt-in video_processing_enabled for Cloudflare Stream

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,6 +96,8 @@ FF_INDEXER_ETHEREUM_WEBSOCKET_URL=YOUR_ETHEREUM_WEBSOCKET_URL
 FF_INDEXER_CLOUDFLARE_ACCOUNT_ID=YOUR_ACCOUNT_ID
 FF_INDEXER_CLOUDFLARE_API_TOKEN=YOUR_API_TOKEN
 FF_INDEXER_MEDIA_ENABLED=false
+# Opt-in Cloudflare Stream uploads for video/*. Default false: skip videos; image/SVG unchanged.
+FF_INDEXER_VIDEO_PROCESSING_ENABLED=false
 
 # API authentication
 FF_INDEXER_AUTH_JWT_PUBLIC_KEY=YOUR_JWT_PUBKEY_PEM
@@ -134,7 +136,7 @@ go run ./cmd/ff-indexer -config config/config.yaml
 ```
 
 - **Without CGO** (`CGO_ENABLED=0`): the media job worker is not started; other subsystems run.
-- **With CGO** and libvips (see [README](README.md) / Docker image): full media pipeline including the `media_index` queue worker when `FF_INDEXER_MEDIA_ENABLED=true`.
+- **With CGO** and libvips (see [README](README.md) / Docker image): full media pipeline including the `media_index` queue worker when `FF_INDEXER_MEDIA_ENABLED=true`. Set `FF_INDEXER_VIDEO_PROCESSING_ENABLED=true` only if you want `video/*` assets ingested to Cloudflare Stream; when unset or `false`, videos are skipped (no upload, no `media_assets` row) while images and SVG handling stay the same.
 - **With `FF_INDEXER_MEDIA_ENABLED=false`**: the media worker is intentionally disabled even in CGO/full builds.
 
 Media worker concurrency and poll settings use `FF_INDEXER_JOBS_MEDIA_WORKER_*` (see [config/.env](config/.env)).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FF-Indexer v2 is a production-ready indexing service designed to capture and ind
 - **Real-time indexing** of blockchain events (mints, transfers, burns, metadata updates)
 - **Metadata resolution** from IPFS, Arweave, ONCHFS, and HTTP sources
 - **Metadata enrichment** from vendor APIs (Art Blocks, fxhash, Foundation, SuperRare, Feral File, Objkt, OpenSea)
-- **Media processing** with Cloudflare Images and Stream
+- **Media processing** with Cloudflare Images; **Cloudflare Stream (video)** only when `video_processing_enabled` / `FF_INDEXER_VIDEO_PROCESSING_ENABLED` is set (default off)
 - **Provenance tracking** with full blockchain event history
 - **Owner-based indexing** for wallet-based queries
 
@@ -65,7 +65,7 @@ go run ./cmd/ff-indexer -config config/config.yaml
 ```
 
 - Lightweight mode: `CGO_ENABLED=0`, media worker stub only.
-- Full media mode: `CGO_ENABLED=1`, `FF_INDEXER_MEDIA_ENABLED=true`, and Cloudflare media config.
+- Full media mode: `CGO_ENABLED=1`, `FF_INDEXER_MEDIA_ENABLED=true`, and Cloudflare credentials (`account_id`, `api_token`). Images and SVG are ingested to Cloudflare Images as before. **`video/*` URLs are not sent to Cloudflare Stream unless** `FF_INDEXER_VIDEO_PROCESSING_ENABLED=true` (or `video_processing_enabled: true` in YAML); when that flag is off (default), videos are skipped (no Stream API usage, no `media_assets` row for those jobs).
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed local development setup.
 
@@ -84,7 +84,7 @@ All of the following run inside the **`ff-indexer`** process (goroutines) by def
 
 - **Chain ingestion** - Ethereum and Tezos event subscriptions (TzKT for Tezos), ordered in-memory block buffers, monotonic durable cursors, and job enqueue at flush boundaries
 - **Worker core** — polls the `token_index` job queue
-- **Worker media** — polls the `media_index` job queue (requires CGO / full Docker image and is disabled by default unless `FF_INDEXER_MEDIA_ENABLED=true`)
+- **Worker media** — polls the `media_index` job queue (requires CGO / full Docker image and is disabled by default unless `FF_INDEXER_MEDIA_ENABLED=true`). Video upload to Stream is further gated by `FF_INDEXER_VIDEO_PROCESSING_ENABLED` (default `false`); see [DEVELOPMENT.md](DEVELOPMENT.md).
 - **API server** — REST and GraphQL
 - **Sweeper** — Media URL health checks
 

--- a/cmd/ff-indexer/config.yaml.sample
+++ b/cmd/ff-indexer/config.yaml.sample
@@ -54,6 +54,9 @@ jobs:
 
 # Set true only when running the CGO/full media path with Cloudflare credentials configured.
 media_enabled: false
+# When true, video/* URLs are uploaded to Cloudflare Stream (requires media_enabled and cloudflare credentials).
+# Default false: videos are skipped (no Stream API, no media_assets row); images and SVG keep current behavior.
+video_processing_enabled: false
 
 ethereum:
   websocket_url: ""

--- a/cmd/ff-indexer/worker_media.go
+++ b/cmd/ff-indexer/worker_media.go
@@ -101,7 +101,7 @@ func registerWorkerMedia(
 
 	dataURIChecker := uri.NewDataURIChecker()
 
-	mediaProcessor := processor.NewProcessor(httpClient, uriResolver, dataURIChecker, mediaProvider, dataStore, svgRasterizer, fileSystem, ioAdapter, jsonAdapter, mediaDownloader, imageTransformer, wcfg.MaxImageSize, wcfg.MaxVideoSize)
+	mediaProcessor := processor.NewProcessor(httpClient, uriResolver, dataURIChecker, mediaProvider, dataStore, svgRasterizer, fileSystem, ioAdapter, jsonAdapter, mediaDownloader, imageTransformer, wcfg.MaxImageSize, wcfg.MaxVideoSize, wcfg.VideoProcessingEnabled)
 
 	mediaExecutor := workflows.NewMediaExecutor(dataStore, mediaProcessor)
 	jobQueue := jobs.NewJobQueue(dataStore, jsonAdapter)

--- a/config/.env
+++ b/config/.env
@@ -91,6 +91,9 @@ FF_INDEXER_VENDORS_OPENSEA_API_KEY=
 # Cloudflare Configuration (worker-media)
 # ----------------
 FF_INDEXER_MEDIA_ENABLED=false
+# When true, video/* URLs are uploaded to Cloudflare Stream (requires MEDIA_ENABLED=true).
+# Default false: videos are skipped (no Stream API, no media_assets row); images and SVG unchanged.
+FF_INDEXER_VIDEO_PROCESSING_ENABLED=false
 FF_INDEXER_CLOUDFLARE_ACCOUNT_ID=
 FF_INDEXER_CLOUDFLARE_API_TOKEN=
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,14 +238,17 @@ type WorkerMediaConfig struct {
 	Database   DatabaseConfig `mapstructure:"database"`
 	Jobs       JobsConfig     `mapstructure:"jobs"`
 	// Security mirrors AppConfig.security for media-worker outbound HTTP (URI resolution and downloads).
-	Security     SecurityConfig   `mapstructure:"security"`
-	MediaEnabled bool             `mapstructure:"media_enabled"`
-	URI          URIConfig        `mapstructure:"uri"`
-	Cloudflare   CloudflareConfig `mapstructure:"cloudflare"`
-	Rasterizer   RasterizerConfig `mapstructure:"rasterizer"`
-	Transform    TransformConfig  `mapstructure:"transform"`
-	MaxImageSize int64            `mapstructure:"max_image_size"`
-	MaxVideoSize int64            `mapstructure:"max_video_size"`
+	Security     SecurityConfig `mapstructure:"security"`
+	MediaEnabled bool           `mapstructure:"media_enabled"`
+	// VideoProcessingEnabled when true sends video/* URLs to the configured media provider (e.g. Cloudflare Stream).
+	// When false (default), video assets are skipped without upload or DB writes; image and SVG flows are unchanged.
+	VideoProcessingEnabled bool             `mapstructure:"video_processing_enabled"`
+	URI                    URIConfig        `mapstructure:"uri"`
+	Cloudflare             CloudflareConfig `mapstructure:"cloudflare"`
+	Rasterizer             RasterizerConfig `mapstructure:"rasterizer"`
+	Transform              TransformConfig  `mapstructure:"transform"`
+	MaxImageSize           int64            `mapstructure:"max_image_size"`
+	MaxVideoSize           int64            `mapstructure:"max_video_size"`
 }
 
 // MediaHealthSweeperConfig holds configuration for the media health sweeper
@@ -286,21 +289,22 @@ type SSRFAllowlistConfig struct {
 
 // AppConfig is the configuration for the single-process ff-indexer binary.
 type AppConfig struct {
-	BaseConfig         `mapstructure:",squash"`
-	Server             ServerConfig             `mapstructure:"server"`
-	Database           DatabaseConfig           `mapstructure:"database"`
-	Auth               AuthConfig               `mapstructure:"auth"`
-	Jobs               JobsConfig               `mapstructure:"jobs"`
-	MediaEnabled       bool                     `mapstructure:"media_enabled"`
-	Ethereum           EthereumConfig           `mapstructure:"ethereum"`
-	Tezos              TezosConfig              `mapstructure:"tezos"`
-	Vendors            VendorsConfig            `mapstructure:"vendors"`
-	URI                URIConfig                `mapstructure:"uri"`
-	RateLimiter        RateLimiterConfig        `mapstructure:"rate_limiter"`
-	Cloudflare         CloudflareConfig         `mapstructure:"cloudflare"`
-	Rasterizer         RasterizerConfig         `mapstructure:"rasterizer"`
-	Transform          TransformConfig          `mapstructure:"transform"`
-	MediaHealthSweeper MediaHealthSweeperConfig `mapstructure:"media_health_sweeper"`
+	BaseConfig             `mapstructure:",squash"`
+	Server                 ServerConfig             `mapstructure:"server"`
+	Database               DatabaseConfig           `mapstructure:"database"`
+	Auth                   AuthConfig               `mapstructure:"auth"`
+	Jobs                   JobsConfig               `mapstructure:"jobs"`
+	MediaEnabled           bool                     `mapstructure:"media_enabled"`
+	VideoProcessingEnabled bool                     `mapstructure:"video_processing_enabled"`
+	Ethereum               EthereumConfig           `mapstructure:"ethereum"`
+	Tezos                  TezosConfig              `mapstructure:"tezos"`
+	Vendors                VendorsConfig            `mapstructure:"vendors"`
+	URI                    URIConfig                `mapstructure:"uri"`
+	RateLimiter            RateLimiterConfig        `mapstructure:"rate_limiter"`
+	Cloudflare             CloudflareConfig         `mapstructure:"cloudflare"`
+	Rasterizer             RasterizerConfig         `mapstructure:"rasterizer"`
+	Transform              TransformConfig          `mapstructure:"transform"`
+	MediaHealthSweeper     MediaHealthSweeperConfig `mapstructure:"media_health_sweeper"`
 
 	EthereumTokenSweepStartBlock uint64 `mapstructure:"ethereum_token_sweep_start_block"`
 	TezosTokenSweepStartBlock    uint64 `mapstructure:"tezos_token_sweep_start_block"`
@@ -463,17 +467,18 @@ func (a *AppConfig) ToWorkerCoreConfig() *WorkerCoreConfig {
 // ToWorkerMediaConfig maps AppConfig for the media-indexing job worker.
 func (a *AppConfig) ToWorkerMediaConfig() *WorkerMediaConfig {
 	return &WorkerMediaConfig{
-		BaseConfig:   a.BaseConfig,
-		Database:     a.Database,
-		Jobs:         a.Jobs,
-		Security:     a.Security,
-		MediaEnabled: a.MediaEnabled,
-		URI:          a.URI,
-		Cloudflare:   a.Cloudflare,
-		Rasterizer:   a.Rasterizer,
-		Transform:    a.Transform,
-		MaxImageSize: a.MaxImageSize,
-		MaxVideoSize: a.MaxVideoSize,
+		BaseConfig:             a.BaseConfig,
+		Database:               a.Database,
+		Jobs:                   a.Jobs,
+		Security:               a.Security,
+		MediaEnabled:           a.MediaEnabled,
+		VideoProcessingEnabled: a.VideoProcessingEnabled,
+		URI:                    a.URI,
+		Cloudflare:             a.Cloudflare,
+		Rasterizer:             a.Rasterizer,
+		Transform:              a.Transform,
+		MaxImageSize:           a.MaxImageSize,
+		MaxVideoSize:           a.MaxVideoSize,
 	}
 }
 
@@ -517,6 +522,7 @@ func applyAppConfigDefaults(v *viper.Viper) {
 	v.SetDefault("jobs.media_worker.cancel_interval", 5*time.Second)
 
 	v.SetDefault("media_enabled", false)
+	v.SetDefault("video_processing_enabled", false)
 
 	// Chains
 	v.SetDefault("ethereum.chain_id", "eip155:1")
@@ -673,6 +679,7 @@ func bindAllEnvVars(v *viper.Viper) {
 		"jobs.media_worker.batch_size",
 		"jobs.media_worker.cancel_interval",
 		"media_enabled",
+		"video_processing_enabled",
 		// Vendors
 		"vendors.artblocks_url",
 		"vendors.feralfile_url",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -284,6 +284,60 @@ FF_INDEXER_TEZOS_WEBSOCKET_URL=wss://ws.tzkt.io
 	assert.False(t, cfg.ToWorkerMediaConfig().MediaEnabled)
 }
 
+func TestLoadAppConfig_VideoProcessingEnabledDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	yaml := `
+database:
+  host: localhost
+  user: u
+  password: p
+  dbname: db
+jobs:
+  token_queue: token_index
+  media_queue: media_index
+ethereum:
+  rpc_url: https://rpc.example.com
+  websocket_url: wss://ws.example.com
+tezos:
+  api_url: https://api.tzkt.io
+  websocket_url: wss://ws.tzkt.io
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(yaml), 0600))
+
+	cfg, err := LoadAppConfig(configPath, "")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.False(t, cfg.VideoProcessingEnabled, "video_processing_enabled should default to false")
+	assert.False(t, cfg.ToWorkerMediaConfig().VideoProcessingEnabled, "WorkerMediaConfig should inherit false default")
+}
+
+func TestLoadAppConfig_VideoProcessingEnabledFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	envDir := filepath.Join(tmpDir, "env")
+	require.NoError(t, os.MkdirAll(envDir, 0750))
+
+	envContent := `FF_INDEXER_VIDEO_PROCESSING_ENABLED=true
+FF_INDEXER_DATABASE_HOST=localhost
+FF_INDEXER_DATABASE_USER=u
+FF_INDEXER_DATABASE_PASSWORD=p
+FF_INDEXER_DATABASE_DBNAME=db
+FF_INDEXER_ETHEREUM_RPC_URL=https://rpc.example.com
+FF_INDEXER_ETHEREUM_WEBSOCKET_URL=wss://ws.example.com
+FF_INDEXER_TEZOS_API_URL=https://api.tzkt.io
+FF_INDEXER_TEZOS_WEBSOCKET_URL=wss://ws.tzkt.io
+FF_INDEXER_JOBS_TOKEN_QUEUE=token_index
+`
+	require.NoError(t, os.WriteFile(filepath.Join(envDir, ".env"), []byte(envContent), 0600))
+
+	cfg, err := LoadAppConfig("", envDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.True(t, cfg.VideoProcessingEnabled, "env var should enable video processing")
+	assert.True(t, cfg.ToWorkerMediaConfig().VideoProcessingEnabled, "WorkerMediaConfig should inherit enabled state")
+}
+
 func TestValidateSecurityConfig_allowlistDomainTooBroad(t *testing.T) {
 	cfg := &AppConfig{}
 	cfg.Security.SSRFProtection.Allowlist.Domains = []string{"com"}

--- a/internal/media/processor/processor.go
+++ b/internal/media/processor/processor.go
@@ -69,11 +69,14 @@ type processor struct {
 	filesystem adapter.FileSystem
 
 	// Configuration
-	maxImageSize int64
-	maxVideoSize int64
+	maxImageSize           int64
+	maxVideoSize           int64
+	videoProcessingEnabled bool
 }
 
-// NewProcessor creates a new Processor instance
+// NewProcessor creates a new Processor instance.
+//
+// When videoProcessingEnabled is false, video/* sources are skipped after probe (no provider uploads, no DB row).
 func NewProcessor(
 	httpClient adapter.HTTPClient,
 	uriResolver uri.Resolver,
@@ -87,21 +90,23 @@ func NewProcessor(
 	dl downloader.Downloader,
 	trans transformer.Transformer,
 	maxImageSize int64,
-	maxVideoSize int64) Processor {
+	maxVideoSize int64,
+	videoProcessingEnabled bool) Processor {
 	return &processor{
-		httpClient:   httpClient,
-		uriResolver:  uriResolver,
-		dataChecker:  dataChecker,
-		provider:     provider,
-		store:        st,
-		rasterizer:   svgRasterizer,
-		filesystem:   filesystem,
-		io:           io,
-		json:         json,
-		downloader:   dl,
-		transformer:  trans,
-		maxImageSize: maxImageSize,
-		maxVideoSize: maxVideoSize,
+		httpClient:             httpClient,
+		uriResolver:            uriResolver,
+		dataChecker:            dataChecker,
+		provider:               provider,
+		store:                  st,
+		rasterizer:             svgRasterizer,
+		filesystem:             filesystem,
+		io:                     io,
+		json:                   json,
+		downloader:             dl,
+		transformer:            trans,
+		maxImageSize:           maxImageSize,
+		maxVideoSize:           maxVideoSize,
+		videoProcessingEnabled: videoProcessingEnabled,
 	}
 }
 
@@ -438,6 +443,12 @@ func (p *processor) Process(ctx context.Context, sourceURL string) error {
 		if probe.isDataURI {
 			logger.WarnCtx(ctx, "Video data URI is not supported", zap.String("mime_type", probe.contentType))
 			return domain.ErrUnsupportedMediaFile
+		}
+		if !p.videoProcessingEnabled {
+			logger.InfoCtx(ctx, "Video processing disabled, skipping video upload",
+				zap.String("sourceURL", sourceURL),
+				zap.String("mime_type", probe.contentType))
+			return nil
 		}
 		uploadResult, err = p.processVideo(ctx, sourceURL, probe, uploadMetadata)
 		if err != nil {

--- a/internal/media/processor/processor_test.go
+++ b/internal/media/processor/processor_test.go
@@ -5,6 +5,8 @@ package processor_test
 import (
 	"context"
 	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -120,8 +122,127 @@ func TestProcess_DataURIImage(t *testing.T) {
 		trans,
 		10*1024*1024,
 		10*1024*1024,
+		false,
 	)
 
 	err := proc.Process(ctx, testDataURIPNG)
 	require.NoError(t, err)
+}
+
+func TestProcess_VideoDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	jsonAdapter := adapter.NewJSON()
+	videoURL := "https://example.com/a.mp4"
+
+	httpClient := mocks.NewMockHTTPClient(ctrl)
+	uriResolver := mocks.NewMockURIResolver(ctrl)
+	dataChecker := mocks.NewMockDataURIChecker(ctrl)
+	st := mocks.NewMockStore(ctrl)
+	raster := mocks.NewMockRasterizer(ctrl)
+	fs := mocks.NewMockFileSystem(ctrl)
+	ioAdapter := mocks.NewMockIO(ctrl)
+	dl := mocks.NewMockDownloader(ctrl)
+	trans := mocks.NewMockTransformer(ctrl)
+	provider := mocks.NewMockMediaProvider(ctrl)
+
+	provider.EXPECT().Name().Return("cloudflare").AnyTimes()
+
+	httpClient.EXPECT().Head(gomock.Any(), videoURL).Return(&http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{"video/mp4"}},
+		ContentLength: 1024,
+		Body:          io.NopCloser(strings.NewReader("")),
+	}, nil)
+
+	proc := processor.NewProcessor(
+		httpClient,
+		uriResolver,
+		dataChecker,
+		provider,
+		st,
+		raster,
+		fs,
+		ioAdapter,
+		jsonAdapter,
+		dl,
+		trans,
+		10*1024*1024,
+		300*1024*1024,
+		false,
+	)
+
+	require.NoError(t, proc.Process(ctx, videoURL))
+}
+
+func TestProcess_VideoEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	jsonAdapter := adapter.NewJSON()
+	videoURL := "https://example.com/a.mp4"
+
+	httpClient := mocks.NewMockHTTPClient(ctrl)
+	uriResolver := mocks.NewMockURIResolver(ctrl)
+	dataChecker := mocks.NewMockDataURIChecker(ctrl)
+	st := mocks.NewMockStore(ctrl)
+	raster := mocks.NewMockRasterizer(ctrl)
+	fs := mocks.NewMockFileSystem(ctrl)
+	ioAdapter := mocks.NewMockIO(ctrl)
+	dl := mocks.NewMockDownloader(ctrl)
+	trans := mocks.NewMockTransformer(ctrl)
+	provider := mocks.NewMockMediaProvider(ctrl)
+
+	provider.EXPECT().Name().Return("cloudflare").AnyTimes()
+
+	httpClient.EXPECT().Head(gomock.Any(), videoURL).Return(&http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{"video/mp4"}},
+		ContentLength: 1024,
+		Body:          io.NopCloser(strings.NewReader("")),
+	}, nil)
+
+	provider.EXPECT().
+		UploadVideo(gomock.Any(), videoURL, gomock.Any()).
+		Return(&mediaprovider.UploadResult{
+			ProviderAssetID: "vid-1",
+			VariantURLs: map[string]string{
+				"hls": "https://customer.example.cloudflarestream.com/vid/manifest/video.m3u8",
+			},
+			ProviderMetadata: map[string]interface{}{
+				"media_type": "video",
+			},
+		}, nil)
+
+	st.EXPECT().
+		CreateMediaAsset(ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input store.CreateMediaAssetInput) (*schema.MediaAsset, error) {
+			require.Equal(t, videoURL, input.SourceURL)
+			require.NotNil(t, input.MimeType)
+			require.Equal(t, "video/mp4", *input.MimeType)
+			require.Equal(t, schema.StorageProviderCloudflare, input.Provider)
+			return &schema.MediaAsset{ID: 1}, nil
+		})
+
+	proc := processor.NewProcessor(
+		httpClient,
+		uriResolver,
+		dataChecker,
+		provider,
+		st,
+		raster,
+		fs,
+		ioAdapter,
+		jsonAdapter,
+		dl,
+		trans,
+		10*1024*1024,
+		300*1024*1024,
+		true,
+	)
+
+	require.NoError(t, proc.Process(ctx, videoURL))
 }


### PR DESCRIPTION
## Problem

Cloudflare video ingestion ran unconditionally in the media processor whenever a `video/*` URL was probed. Operators who only need images and SVG processing still incurred Cloudflare Stream usage and operational surface.

## Why It Matters

Cuts Stream API usage and complexity when video is out of scope. Images (`direct upload`, transform, SVG rasterization) keep the same behavior. Video handling becomes explicit via configuration.

## Acceptance Checks

- [x] With video processing **off** (default), `Process` never calls the provider `UploadVideo` path for URL-based `video/*`; skip is explicit (INFO log, `nil` return, no `media_assets` row).
- [x] With video **off**, image and SVG paths are unchanged.
- [x] With video **on** (`video_processing_enabled: true` / `FF_INDEXER_VIDEO_PROCESSING_ENABLED=true`), behavior matches prior video handling (Stream upload + DB persist). Config is documented in `cmd/ff-indexer/config.yaml.sample`, `config/.env`, and `DEVELOPMENT.md`.

## Human Owner

_(assign in GitHub UI)_

## How The Agent Will Be Used

Implementation, tests, docs, local `make check`, reviewer follow-up (config tests + `config/.env`), and PR preparation.

## PR or Deploy Link

_(this PR)_

