### PR TITLE
Reduce Sentry noise from media source timeouts

### DIFF
--- a/internal/workflows/index_media_wf.go
+++ b/internal/workflows/index_media_wf.go
@@ -105,11 +105,18 @@ func logMediaIndexFailure(ctx context.Context, url string, err error) {
 	)
 }
 
-// isExpectedMediaSourceTimeout reports whether err is the known transform-source fetch timeout.
+// isExpectedMediaSourceTimeout reports whether err is a known media-source fetch timeout.
 //
-// Reason: The transformer wraps HTTP GET failures with "failed to get response"; combining that
-// marker with context.DeadlineExceeded limits Sentry suppression to external media fetches instead
-// of every possible media workflow deadline, such as database or provider API timeouts.
+// Reason: Probe and transform both fetch externally hosted media and wrap HTTP failures with stable
+// source-fetch markers. Combining those markers with context.DeadlineExceeded limits Sentry
+// suppression to external media fetches instead of every possible media workflow deadline, such as
+// database or provider API timeouts.
 func isExpectedMediaSourceTimeout(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded) && strings.Contains(err.Error(), "failed to get response")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "failed to get response") ||
+		strings.Contains(msg, "failed to get content-type via partial GET")
 }

--- a/internal/workflows/index_media_wf.go
+++ b/internal/workflows/index_media_wf.go
@@ -4,7 +4,9 @@ package workflows
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -61,22 +63,53 @@ func (w *mediaWorkflows) IndexMultipleMediaWorkflow(ctx context.Context, urls []
 	return nil
 }
 
-// IndexMediaWorkflow handles the media processing for a single URL
-// This workflow uses a separate task queue with higher execution time
+// IndexMediaWorkflow handles media processing for a single URL.
+//
+// Reason: Media jobs should still fail when processing cannot finish so operators can inspect
+// jobs.last_error, but expected third-party source timeouts should not page engineers through Sentry.
+// Trade-offs: Known source-fetch timeouts are warning logs; unexpected failures remain error logs.
+// Constraints: Returning the original error preserves the worker's failed-job behavior.
 func (w *mediaWorkflows) IndexMediaWorkflow(ctx context.Context, url string) error {
 	logger.InfoCtx(ctx, "Starting media indexing", zap.String("url", url))
 
 	// Execute the media indexing activity
 	err := w.executor.IndexMediaFile(ctx, url)
 	if err != nil {
-		logger.ErrorCtx(ctx,
-			fmt.Errorf("failed to index media file"),
-			zap.Error(err),
-			zap.String("url", url),
-		)
+		logMediaIndexFailure(ctx, url, err)
 		return err
 	}
 
 	logger.InfoCtx(ctx, "Media indexed successfully", zap.String("url", url))
 	return nil
+}
+
+// logMediaIndexFailure records a failed media job at the appropriate operational severity.
+//
+// Reason: Sentry should capture unexpected application failures, not routine source gateway
+// timeouts from externally hosted media. Trade-offs: The job still fails and stores last_error,
+// so operators retain a durable signal without one Sentry event per unavailable media URL.
+func logMediaIndexFailure(ctx context.Context, url string, err error) {
+	if isExpectedMediaSourceTimeout(err) {
+		logger.WarnCtx(ctx,
+			"Media source fetch timed out during indexing",
+			zap.Error(err),
+			zap.String("url", url),
+		)
+		return
+	}
+
+	logger.ErrorCtx(ctx,
+		fmt.Errorf("failed to index media file"),
+		zap.Error(err),
+		zap.String("url", url),
+	)
+}
+
+// isExpectedMediaSourceTimeout reports whether err is the known transform-source fetch timeout.
+//
+// Reason: The transformer wraps HTTP GET failures with "failed to get response"; combining that
+// marker with context.DeadlineExceeded limits Sentry suppression to external media fetches instead
+// of every possible media workflow deadline, such as database or provider API timeouts.
+func isExpectedMediaSourceTimeout(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) && strings.Contains(err.Error(), "failed to get response")
 }

--- a/internal/workflows/index_media_wf_internal_test.go
+++ b/internal/workflows/index_media_wf_internal_test.go
@@ -1,0 +1,27 @@
+//go:build cgo
+
+package workflows
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExpectedMediaSourceTimeout(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("failed to process media file: failed to transform and upload image: transformation failed: failed to get response: %w", context.DeadlineExceeded)
+
+	require.True(t, isExpectedMediaSourceTimeout(err))
+}
+
+func TestIsExpectedMediaSourceTimeout_IgnoresOtherDeadlineFailures(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("failed to check existing media asset: %w", context.DeadlineExceeded)
+
+	require.False(t, isExpectedMediaSourceTimeout(err))
+}

--- a/internal/workflows/index_media_wf_internal_test.go
+++ b/internal/workflows/index_media_wf_internal_test.go
@@ -4,10 +4,16 @@ package workflows
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/require"
+
+	"github.com/feral-file/ff-indexer-v2/internal/logger"
+	"github.com/feral-file/ff-indexer-v2/internal/providers/jobs"
 )
 
 func TestIsExpectedMediaSourceTimeout(t *testing.T) {
@@ -18,10 +24,81 @@ func TestIsExpectedMediaSourceTimeout(t *testing.T) {
 	require.True(t, isExpectedMediaSourceTimeout(err))
 }
 
+func TestIsExpectedMediaSourceTimeout_ProbePartialGETDeadline(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("failed to process media file: failed to get content-type via partial GET: %w", context.DeadlineExceeded)
+
+	require.True(t, isExpectedMediaSourceTimeout(err))
+}
+
 func TestIsExpectedMediaSourceTimeout_IgnoresOtherDeadlineFailures(t *testing.T) {
 	t.Parallel()
 
 	err := fmt.Errorf("failed to check existing media asset: %w", context.DeadlineExceeded)
 
 	require.False(t, isExpectedMediaSourceTimeout(err))
+}
+
+func TestIndexMediaWorkflow_PartialGETDeadlineWarnsWithoutSentryEvent(t *testing.T) {
+	transport := initializeSentryTestLogger(t)
+
+	url := "https://example.com/media.jpg"
+	expectedErr := fmt.Errorf("failed to process media file: failed to get content-type via partial GET: %w", context.DeadlineExceeded)
+	mw := NewMediaWorkflows(
+		&stubMediaExecutor{err: expectedErr},
+		jobs.NopQueue{},
+		MediaWorkflowsConfig{MediaTaskQueue: "media_index"},
+	)
+
+	err := mw.IndexMediaWorkflow(context.Background(), url)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	logger.Flush(time.Second)
+	require.Empty(t, transport.Events())
+}
+
+func TestIndexMediaWorkflow_UnexpectedFailureStillSendsSentryEvent(t *testing.T) {
+	transport := initializeSentryTestLogger(t)
+
+	url := "https://example.com/media.jpg"
+	expectedErr := errors.New("database unavailable")
+	mw := NewMediaWorkflows(
+		&stubMediaExecutor{err: expectedErr},
+		jobs.NopQueue{},
+		MediaWorkflowsConfig{MediaTaskQueue: "media_index"},
+	)
+
+	err := mw.IndexMediaWorkflow(context.Background(), url)
+
+	require.ErrorIs(t, err, expectedErr)
+	logger.Flush(time.Second)
+	require.Len(t, transport.Events(), 1)
+}
+
+func initializeSentryTestLogger(t *testing.T) *sentry.MockTransport {
+	t.Helper()
+
+	transport := &sentry.MockTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://public@example.com/1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, logger.Initialize(logger.Config{
+		Debug:        true,
+		SentryDSN:    "https://public@example.com/1",
+		SentryClient: client,
+	}))
+
+	return transport
+}
+
+type stubMediaExecutor struct {
+	err error
+}
+
+func (e *stubMediaExecutor) IndexMediaFile(context.Context, string) error {
+	return e.err
 }


### PR DESCRIPTION
## Summary
- Downgrade expected media source fetch timeouts from `ErrorCtx` to `WarnCtx` in the media workflow so routine gateway failures do not create Sentry error events
- Preserve existing job failure behavior so `jobs.last_error` still records the failure for operators
- Add focused tests for the timeout classifier used to suppress only the known external fetch timeout case

## Testing
- `make test-lightweight-build`
- `CGO_ENABLED=1 go test ./internal/workflows`
- `CGO_ENABLED=1 go test -cover ./internal/workflows`
- `make test`
- `CGO_ENABLED=1 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --verbose --new-from-merge-base main`