### PR TITLE
fix(store): include owner-held tokens without provenance in list query

### DIFF
--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -553,7 +553,9 @@ func (s *pgStore) GetTokensByFilter(ctx context.Context, filter TokenQueryFilter
 			Order("last_tx_index DESC").
 			Order("id DESC") // Tiebreaker for deterministic results when timestamps & tx_index are equal
 
-		query = query.Joins("JOIN (?) AS top ON top.token_id = tokens.id", subQuery)
+		// LEFT JOIN so tokens with a balance but no owner-specific provenance row are still returned
+		// (e.g. minimal indexing before full provenance backfill). NULL timestamps sort last.
+		query = query.Joins("LEFT JOIN (?) AS top ON top.token_id = tokens.id", subQuery)
 	}
 
 	// Apply viewability filter

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2062,6 +2062,76 @@ func testGetTokensByFilter(t *testing.T, store Store) {
 		assert.Equal(t, token1Data.ID, foundTokens[2], "token1 should be third (lowest tx_index)")
 	})
 
+	t.Run("owner filter with latest provenance sort includes tokens without provenance events", func(t *testing.T) {
+		owner := "0xnoprovenance000000000000000000000000001"
+		contractAddress := "0x0000000000000000000000000000000000080001"
+		tokenNumber := "1"
+		tokenCID := domain.NewTokenCID(domain.ChainEthereumMainnet, domain.StandardERC1155, contractAddress, tokenNumber)
+
+		// Token indexed with balance only (minimal provenance path: no events, no token_ownership_provenance)
+		err := store.CreateTokenWithProvenances(ctx, CreateTokenWithProvenancesInput{
+			Token: CreateTokenInput{
+				TokenCID:        tokenCID.String(),
+				Chain:           domain.ChainEthereumMainnet,
+				Standard:        domain.StandardERC1155,
+				ContractAddress: contractAddress,
+				TokenNumber:     tokenNumber,
+			},
+			Balances: []CreateBalanceInput{
+				{OwnerAddress: owner, Quantity: "1"},
+			},
+			Events: []CreateProvenanceEventInput{},
+		})
+		require.NoError(t, err)
+
+		tokenWithoutProvenance, err := store.GetTokenByTokenCID(ctx, tokenCID.String())
+		require.NoError(t, err)
+		require.NotNil(t, tokenWithoutProvenance)
+
+		// Token with provenance for the same owner (should sort before the eventless token)
+		tokenWithProvenance := buildTestTokenMint(
+			domain.ChainEthereumMainnet,
+			domain.StandardERC721,
+			"0x0000000000000000000000000000000000080002",
+			"2",
+			owner,
+		)
+		tokenWithProvenance.ProvenanceEvent.Timestamp = time.Now().UTC().Add(-1 * time.Hour)
+		err = store.CreateTokenMint(ctx, tokenWithProvenance)
+		require.NoError(t, err)
+
+		tokenWithProvenanceData, err := store.GetTokenByTokenCID(ctx, tokenWithProvenance.Token.TokenCID)
+		require.NoError(t, err)
+
+		tokens, err := store.GetTokensByFilter(ctx, TokenQueryFilter{
+			Owners:            []string{owner},
+			Limit:             10,
+			IncludeUnviewable: true,
+			SortBy:            TokenSortByLatestProvenance,
+			SortOrder:         SortOrderDesc,
+		})
+		require.NoError(t, err)
+
+		var foundWithoutProvenance, foundWithProvenance bool
+		var testTokenOrder []uint64
+		for _, token := range tokens {
+			if token.ID == tokenWithoutProvenance.ID {
+				foundWithoutProvenance = true
+				testTokenOrder = append(testTokenOrder, token.ID)
+			}
+			if token.ID == tokenWithProvenanceData.ID {
+				foundWithProvenance = true
+				testTokenOrder = append(testTokenOrder, token.ID)
+			}
+		}
+
+		assert.True(t, foundWithoutProvenance, "token with balance but no provenance should be included")
+		assert.True(t, foundWithProvenance, "token with provenance should be included")
+		require.Len(t, testTokenOrder, 2, "both test tokens should appear in owner-filtered results")
+		assert.Equal(t, tokenWithProvenanceData.ID, testTokenOrder[0], "token with provenance should sort before token without")
+		assert.Equal(t, tokenWithoutProvenance.ID, testTokenOrder[1], "token without provenance should sort last (NULLS LAST)")
+	})
+
 	t.Run("IncludeBrokenMedia flag filters tokens by media health", func(t *testing.T) {
 		// Create tokens with different media health scenarios
 		healthyAnimAddr := "0x0000000000000000000000000000000000050001"


### PR DESCRIPTION
## Problem

What is changing?

Owner-filtered token list queries with `sort_by=latest_provenance` (the API default) used an `INNER JOIN` on `token_ownership_provenance`. Tokens that matched the owner filter via `balances` but had no owner-specific provenance row were excluded from results entirely.

This affected tokens indexed via the minimal provenance path (balance-only, before full provenance backfill) and legacy contracts where full provenance indexing is skipped.

## Why It Matters

Why should we land this now?

Portfolio queries (`?owner=...&sort_by=latest_provenance`) silently dropped legitimately owned tokens during the window between minimal indexing and full provenance backfill, and permanently for tokens that never receive provenance events. Clients could miss tokens that are already marked queryable via webhook.

## Acceptance Checks

- [x] Owner-filtered `latest_provenance` queries return tokens with balances but no `token_ownership_provenance` row
- [x] Tokens without owner-specific provenance sort after tokens with provenance (`NULLS LAST`)
- [x] Regression test added in `internal/store/store_test.go`
- [x] `make check` passes locally

## Human Owner

Who owns the task outcome?

_(fill in)_

## How The Agent Will Be Used

How did the agent help with implementation, review, verification, or follow-up?

Investigated query path in `GetTokensByFilter`, confirmed exclusion via `INNER JOIN`, changed to `LEFT JOIN`, added regression test, and ran `make check`.

## PR or Deploy Link

Link the PR, preview, deploy, or release if available.

_(this PR)_