### PR TITLE
fix(store): enforce idempotent acquired/released token_events

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -170,6 +170,48 @@ Migrations are stored in `db/migrations/`. Apply migrations:
 psql -h localhost -U postgres -d ff_indexer -f db/migrations/001.sql
 ```
 
+**⚠️ CRITICAL: Migration ordering for deployments**
+
+Some migrations introduce database constraints that application code depends on (e.g., unique indexes with `ON CONFLICT` clauses). **You MUST run migrations before deploying new application code.**
+
+**Required deployment sequence:**
+
+1. **Stop or pause** traffic to the application (optional for blue-green deployments)
+2. **Run migrations** on all database instances
+3. **Wait for migration completion** across all replicas/shards
+4. **Verify migrations** succeeded (check indexes/constraints exist)
+5. **Deploy** the new application version
+6. **Resume** traffic
+
+**Migration 017 (token_events uniqueness) - REQUIRED:**
+
+This migration adds the `token_events_ownership_unique` partial index that application code depends on for idempotent ownership event insertion.
+
+- **If migration has NOT run:** Application will fail at runtime with PostgreSQL error:
+  ```
+  ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10)
+  ```
+- **If app deploys before migration:** All ownership event inserts will fail, breaking token indexing
+- **There is NO fallback:** The application will explicitly fail to prevent data corruption
+
+**Migration verification:**
+
+```bash
+# Verify migration 017 index exists
+psql -h localhost -U postgres -d ff_indexer -c "\d token_events_ownership_unique"
+
+# Or check in SQL
+SELECT indexname, indexdef 
+FROM pg_indexes 
+WHERE tablename = 'token_events' 
+  AND indexname = 'token_events_ownership_unique';
+```
+
+**For production deployments:**
+- Use blue-green deployment strategy to avoid downtime
+- Run migrations on blue environment, verify, then switch traffic
+- Or schedule maintenance window for migration + deployment
+
 ### Reset Database
 
 To reset the database (WARNING: deletes all data):

--- a/db/init_pg_db.sql
+++ b/db/init_pg_db.sql
@@ -374,6 +374,13 @@ CREATE INDEX idx_token_events_created_id ON token_events(created_at ASC, id ASC)
 -- Index for broadcast events by token_id (optimizes JOIN with balances table for scalability)
 CREATE INDEX idx_token_events_token_created ON token_events(token_id, created_at ASC, id ASC) WHERE owner_address IS NULL;
 
+-- One acquired/released event per token-owner-transfer (tx_hash in metadata); idempotent ingestion
+CREATE UNIQUE INDEX token_events_ownership_unique
+ON token_events (token_id, owner_address, event_type, (metadata->>'tx_hash'))
+WHERE event_type IN ('acquired', 'released')
+  AND owner_address IS NOT NULL
+  AND (metadata->>'tx_hash') IS NOT NULL;
+
 -- Provenance Events table indexes
 CREATE INDEX idx_provenance_events_token_id ON provenance_events (token_id);
 CREATE INDEX idx_provenance_events_chain ON provenance_events (chain);

--- a/db/migrations/017.sql
+++ b/db/migrations/017.sql
@@ -1,0 +1,38 @@
+-- Migration 017: Deduplicate ownership token_events and enforce per-transfer uniqueness
+-- See https://github.com/feral-file/ff-indexer-v2/issues/46
+--
+-- ⚠️ CRITICAL: This migration MUST be applied BEFORE deploying application code that depends on it.
+-- The application uses ON CONFLICT with token_events_ownership_unique and will fail at runtime
+-- if this index does not exist. There is no fallback behavior.
+--
+-- Deployment sequence:
+--   1. Run this migration on all database instances
+--   2. Verify the index exists (see DEVELOPMENT.md for verification commands)
+--   3. Deploy the new application version
+
+BEGIN;
+
+-- Remove duplicate acquired/released rows that share token, owner, event type, and tx_hash.
+-- Keep the earliest row (lowest id) as the canonical record.
+DELETE FROM token_events te
+WHERE te.event_type IN ('acquired', 'released')
+  AND te.owner_address IS NOT NULL
+  AND te.metadata->>'tx_hash' IS NOT NULL
+  AND te.id NOT IN (
+      SELECT MIN(id)
+      FROM token_events
+      WHERE event_type IN ('acquired', 'released')
+        AND owner_address IS NOT NULL
+        AND metadata->>'tx_hash' IS NOT NULL
+      GROUP BY token_id, owner_address, event_type, metadata->>'tx_hash'
+  );
+
+CREATE UNIQUE INDEX token_events_ownership_unique
+ON token_events (token_id, owner_address, event_type, (metadata->>'tx_hash'))
+WHERE event_type IN ('acquired', 'released')
+  AND owner_address IS NOT NULL
+  AND (metadata->>'tx_hash') IS NOT NULL;
+
+COMMENT ON INDEX token_events_ownership_unique IS 'One acquired/released token_event per token-owner-transfer (tx_hash in metadata)';
+
+COMMIT;

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -18,7 +18,7 @@ The database includes the following main tables:
 - `token_metadata` - NFT metadata (name, description, media, attributes, etc.)
 - `enrichment_sources` - Additional data sources enriching token information
 - `balances` - Current token ownership balances (multi-edition tokens)
-- `token_events` - Unified log for collection sync (`acquired` / `released` / metadata / viewability)
+- `token_events` - Unified log for collection sync (`acquired` / `released` / metadata / viewability); ownership rows with `metadata.tx_hash` are unique per `(token_id, owner_address, event_type, tx_hash)` via `token_events_ownership_unique`
 - `provenance_events` - Historical provenance events (mint, transfer, burn, etc.)
 - `media_assets` - Media files associated with tokens (images, videos, etc.)
 - `token_media_health` - Health status of token media URLs

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -2914,9 +2914,37 @@ func (s *pgStore) GetTokenChangesByOwnerSinceCheckpoint(ctx context.Context, own
 	return events, nil
 }
 
-// createTokenEvent inserts a token event into the token_events table
-// Should be called within a transaction after ownership or attribute changes
+// isOwnershipTokenEventType reports whether the event type is acquired or released.
+func isOwnershipTokenEventType(eventType schema.TokenEventType) bool {
+	return eventType == schema.EventTypeAcquired || eventType == schema.EventTypeReleased
+}
+
+// ownershipTokenEventTxHash returns metadata tx_hash when present (used for uniqueness).
+func ownershipTokenEventTxHash(metadata []byte) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	var meta struct {
+		TxHash string `json:"tx_hash"`
+	}
+	if err := json.Unmarshal(metadata, &meta); err != nil {
+		return ""
+	}
+	return meta.TxHash
+}
+
+// createTokenEvent inserts a token event into the token_events table.
+// Should be called within a transaction after ownership or attribute changes.
+//
+// Acquired/released rows with owner_address and metadata.tx_hash use ON CONFLICT DO NOTHING
+// against token_events_ownership_unique so concurrent ingestion stays idempotent.
 func (s *pgStore) createTokenEvent(tx *gorm.DB, tokenID uint64, eventType schema.TokenEventType, ownerAddress *string, occurredAt time.Time, metadata []byte) error {
+	if isOwnershipTokenEventType(eventType) && ownerAddress != nil {
+		if txHash := ownershipTokenEventTxHash(metadata); txHash != "" {
+			return s.createOwnershipTokenEventIdempotent(tx, tokenID, eventType, *ownerAddress, occurredAt, metadata)
+		}
+	}
+
 	event := schema.TokenEvent{
 		TokenID:      tokenID,
 		EventType:    eventType,
@@ -2927,6 +2955,28 @@ func (s *pgStore) createTokenEvent(tx *gorm.DB, tokenID uint64, eventType schema
 
 	if err := tx.Create(&event).Error; err != nil {
 		return fmt.Errorf("failed to create token event: %w", err)
+	}
+
+	return nil
+}
+
+// createOwnershipTokenEventIdempotent inserts acquired/released rows guarded by token_events_ownership_unique.
+// Requires migration 017 (token_events_ownership_unique index) to have been applied.
+// If the index does not exist, this will fail with a clear Postgres error.
+func (s *pgStore) createOwnershipTokenEventIdempotent(tx *gorm.DB, tokenID uint64, eventType schema.TokenEventType, ownerAddress string, occurredAt time.Time, metadata []byte) error {
+	err := tx.Exec(`
+		INSERT INTO token_events (token_id, event_type, owner_address, occurred_at, metadata)
+		VALUES (?, ?, ?, ?, ?::jsonb)
+		ON CONFLICT (token_id, owner_address, event_type, (metadata->>'tx_hash'))
+		WHERE event_type IN ('acquired', 'released')
+		  AND owner_address IS NOT NULL
+		  AND (metadata->>'tx_hash') IS NOT NULL
+		DO NOTHING`,
+		tokenID, string(eventType), ownerAddress, occurredAt, metadata,
+	).Error
+
+	if err != nil {
+		return fmt.Errorf("failed to create ownership token event (requires migration 017 with token_events_ownership_unique index): %w", err)
 	}
 
 	return nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 
 	"github.com/feral-file/ff-indexer-v2/internal/domain"
 	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
@@ -93,6 +95,22 @@ func buildTestProvenanceEventWithTime(chain domain.Chain, eventType schema.Prove
 	}
 }
 
+// countOwnershipTokenEventsForOwner counts acquired/released token_events for a token-owner pair.
+func countOwnershipTokenEventsForOwner(t *testing.T, store Store, owner string, tokenID uint64, eventType schema.TokenEventType) int {
+	t.Helper()
+
+	events, err := store.GetTokenChangesByOwnerSinceCheckpoint(context.Background(), owner, time.Time{}, 0, 1000)
+	require.NoError(t, err)
+
+	n := 0
+	for _, evt := range events {
+		if evt.TokenID == tokenID && evt.EventType == eventType {
+			n++
+		}
+	}
+	return n
+}
+
 // buildTestTokenMint creates a complete token mint input
 func buildTestTokenMint(chain domain.Chain, standard domain.ChainStandard, contract, tokenNum string, owner string) CreateTokenMintInput {
 	token := buildTestToken(chain, standard, contract, tokenNum)
@@ -162,39 +180,6 @@ func testCreateTokenMint(t *testing.T, store Store) {
 		assert.Equal(t, uint64(1), eventTotal)
 	})
 
-	t.Run("duplicate event with same token and addresses should be idempotent", func(t *testing.T) {
-		input := buildTestTokenMint(
-			domain.ChainEthereumMainnet,
-			domain.StandardERC721,
-			"0x2222222222222222222222222222222222222222",
-			"1",
-			"0xowner2222222222222222222222222222222222222",
-		)
-
-		// First mint - should succeed
-		err := store.CreateTokenMint(ctx, input)
-		require.NoError(t, err)
-
-		token1, err := store.GetTokenByTokenCID(ctx, input.Token.TokenCID)
-		require.NoError(t, err)
-		require.NotNil(t, token1)
-
-		// Try to create the SAME token with the SAME tx hash and addresses
-		// This should succeed (idempotent behavior) but not create duplicates
-		input2 := input
-
-		// This should succeed without creating duplicate records
-		// The conflict resolution handles both token and provenance event duplicates gracefully
-		err = store.CreateTokenMint(ctx, input2)
-		require.NoError(t, err)
-
-		// Verify the token still has exactly one provenance event (no duplicates created)
-		events, total, err := store.GetTokenProvenanceEvents(ctx, token1.ID, 10, 0, false)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(1), total)
-		assert.Len(t, events, 1)
-	})
-
 	t.Run("mint ERC1155 token with quantity > 1", func(t *testing.T) {
 		input := buildTestTokenMint(
 			domain.ChainEthereumMainnet,
@@ -245,6 +230,328 @@ func testCreateTokenMint(t *testing.T, store Store) {
 		assert.NotNil(t, token)
 		assert.Equal(t, domain.ChainTezosMainnet, token.Chain)
 		assert.Equal(t, domain.StandardFA2, token.Standard)
+	})
+}
+
+// =============================================================================
+// Test: Ownership token_events idempotency (issue #46)
+// =============================================================================
+
+// testOwnershipTokenEventIdempotency guards against duplicate acquired/released token_events.
+// Mint-retry tests alone cannot catch the bug because duplicate provenance inserts return before
+// updateOwnershipPeriods runs; the concurrent subtest uses committed transactions on testDB.
+func testOwnershipTokenEventIdempotency(t *testing.T, store Store) {
+	ctx := context.Background()
+
+	t.Run("duplicate provenance on mint retry is idempotent for provenance rows only", func(t *testing.T) {
+		input := buildTestTokenMint(
+			domain.ChainEthereumMainnet,
+			domain.StandardERC721,
+			"0x2222222222222222222222222222222222222222",
+			"1",
+			"0xowner2222222222222222222222222222222222222",
+		)
+
+		err := store.CreateTokenMint(ctx, input)
+		require.NoError(t, err)
+
+		token1, err := store.GetTokenByTokenCID(ctx, input.Token.TokenCID)
+		require.NoError(t, err)
+		require.NotNil(t, token1)
+
+		acquiredBeforeRetry := countOwnershipTokenEventsForOwner(t, store, input.Balance.OwnerAddress, token1.ID, schema.EventTypeAcquired)
+		require.Equal(t, 1, acquiredBeforeRetry)
+
+		// Second mint with identical provenance: provenance insert is skipped (ID == 0) and the
+		// handler returns before updateOwnershipPeriods — so this never exercises token_events dedup.
+		err = store.CreateTokenMint(ctx, input)
+		require.NoError(t, err)
+
+		events, total, err := store.GetTokenProvenanceEvents(ctx, token1.ID, 10, 0, false)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), total)
+		assert.Len(t, events, 1)
+
+		acquiredAfterRetry := countOwnershipTokenEventsForOwner(t, store, input.Balance.OwnerAddress, token1.ID, schema.EventTypeAcquired)
+		assert.Equal(t, acquiredBeforeRetry, acquiredAfterRetry)
+	})
+
+	t.Run("distinct provenance rows same tx_hash yield one acquired token_event", func(t *testing.T) {
+		owner := "0xowner3333333333333333333333333333333333333"
+		contract := "0x3333333333333333333333333333333333333333"
+		tokenNum := "1"
+		txHash := "0xsametxhash3333333333333333333333333333333333333333333333333333"
+		tokenCID := domain.NewTokenCID(domain.ChainEthereumMainnet, domain.StandardERC721, contract, tokenNum)
+		zero := domain.ETHEREUM_ZERO_ADDRESS
+
+		err := store.CreateTokenWithProvenances(ctx, CreateTokenWithProvenancesInput{
+			Token: CreateTokenInput{
+				TokenCID:        tokenCID.String(),
+				Chain:           domain.ChainEthereumMainnet,
+				Standard:        domain.StandardERC721,
+				ContractAddress: contract,
+				TokenNumber:     tokenNum,
+				CurrentOwner:    &owner,
+			},
+			Balances: []CreateBalanceInput{{OwnerAddress: owner, Quantity: "1"}},
+			Events:   nil,
+		})
+		require.NoError(t, err)
+
+		token, err := store.GetTokenByTokenCID(ctx, tokenCID.String())
+		require.NoError(t, err)
+
+		// Two provenance rows that share tx_hash and to_address but differ in from_address (allowed by
+		// provenance_events_unique). Both run updateOwnershipPeriods in one transaction.
+		err = store.UpsertTokenBalanceForOwner(ctx, UpsertTokenBalanceForOwnerInput{
+			Token: CreateTokenInput{
+				TokenCID:        tokenCID.String(),
+				Chain:           domain.ChainEthereumMainnet,
+				Standard:        domain.StandardERC721,
+				ContractAddress: contract,
+				TokenNumber:     tokenNum,
+				CurrentOwner:    &owner,
+			},
+			OwnerAddress: owner,
+			Quantity:     "1",
+			Events: []CreateProvenanceEventInput{
+				buildTestProvenanceEvent(
+					domain.ChainEthereumMainnet,
+					schema.ProvenanceEventTypeTransfer,
+					&zero,
+					&owner,
+					"1",
+					txHash,
+					100,
+				),
+				buildTestProvenanceEvent(
+					domain.ChainEthereumMainnet,
+					schema.ProvenanceEventTypeTransfer,
+					nil,
+					&owner,
+					"1",
+					txHash,
+					100,
+				),
+			},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, countOwnershipTokenEventsForOwner(t, store, owner, token.ID, schema.EventTypeAcquired),
+			"same transfer tx_hash must not produce multiple acquired token_events for one owner")
+	})
+
+	t.Run("concurrent updateOwnershipPeriods yields one acquired row", func(t *testing.T) {
+		if testDB == nil {
+			t.Skip("requires PostgreSQL test database from pg_test TestMain")
+		}
+
+		pg, ok := store.(*pgStore)
+		require.True(t, ok, "concurrent ownership token_event test requires PostgreSQL store")
+
+		owner := "0xowner4444444444444444444444444444444444444"
+		input := buildTestTokenMint(
+			domain.ChainEthereumMainnet,
+			domain.StandardERC721,
+			"0x4444444444444444444444444444444444444444",
+			"1",
+			owner,
+		)
+
+		setupTx := testDB.Begin()
+		require.NoError(t, setupTx.Error)
+		setupStore := NewPGStore(setupTx)
+
+		require.NoError(t, setupStore.CreateTokenMint(ctx, input))
+
+		token, err := setupStore.GetTokenByTokenCID(ctx, input.Token.TokenCID)
+		require.NoError(t, err)
+
+		var prov schema.ProvenanceEvent
+		require.NoError(t, setupTx.WithContext(ctx).
+			Where("token_id = ?", token.ID).
+			First(&prov).Error)
+
+		require.NoError(t, setupTx.WithContext(ctx).
+			Where("token_id = ? AND event_type IN ?", token.ID, []string{
+				string(schema.EventTypeAcquired),
+				string(schema.EventTypeReleased),
+			}).
+			Delete(&schema.TokenEvent{}).Error)
+
+		require.NoError(t, setupTx.Commit().Error)
+
+		t.Cleanup(func() {
+			_ = testDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+				if err := tx.Where("token_id = ?", token.ID).Delete(&schema.TokenEvent{}).Error; err != nil {
+					return err
+				}
+				if err := tx.Where("token_id = ?", token.ID).Delete(&schema.ProvenanceEvent{}).Error; err != nil {
+					return err
+				}
+				if err := tx.Where("token_id = ?", token.ID).Delete(&schema.Balance{}).Error; err != nil {
+					return err
+				}
+				return tx.Where("id = ?", token.ID).Delete(&schema.Token{}).Error
+			})
+		})
+
+		const workers = 24
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		errs := make(chan error, workers)
+
+		for range workers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs <- testDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+					return pg.updateOwnershipPeriods(ctx, tx, &prov, domain.StandardERC721)
+				})
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			require.NoError(t, err)
+		}
+
+		var acquiredCount int64
+		require.NoError(t, testDB.WithContext(ctx).
+			Model(&schema.TokenEvent{}).
+			Where("token_id = ? AND owner_address = ? AND event_type = ?",
+				token.ID, owner, schema.EventTypeAcquired).
+			Count(&acquiredCount).Error)
+
+		assert.Equal(t, int64(1), acquiredCount,
+			"concurrent updateOwnershipPeriods for the same transfer must leave exactly one acquired row")
+	})
+
+	t.Run("concurrent updateOwnershipPeriods yields one released row", func(t *testing.T) {
+		if testDB == nil {
+			t.Skip("requires PostgreSQL test database from pg_test TestMain")
+		}
+
+		pg, ok := store.(*pgStore)
+		require.True(t, ok, "concurrent ownership token_event test requires PostgreSQL store")
+
+		owner1 := "0xowner5555555555555555555555555555555555555"
+		owner2 := "0xowner6666666666666666666666666666666666666"
+		input := buildTestTokenMint(
+			domain.ChainEthereumMainnet,
+			domain.StandardERC721,
+			"0x5555555555555555555555555555555555555555",
+			"2",
+			owner1,
+		)
+
+		setupTx := testDB.Begin()
+		require.NoError(t, setupTx.Error)
+		setupStore := NewPGStore(setupTx)
+
+		require.NoError(t, setupStore.CreateTokenMint(ctx, input))
+
+		token, err := setupStore.GetTokenByTokenCID(ctx, input.Token.TokenCID)
+		require.NoError(t, err)
+
+		// For ERC721 released logic: must have a prior acquired event for owner1.
+		// Create that directly before setting up the transfer provenance.
+		acquiredMeta, _ := json.Marshal(schema.AcquisitionMetadata{TxHash: "0xminthash", Quantity: "1"})
+		require.NoError(t, setupTx.Create(&schema.TokenEvent{
+			TokenID:      token.ID,
+			EventType:    schema.EventTypeAcquired,
+			OwnerAddress: &owner1,
+			OccurredAt:   time.Now().UTC().Add(-1 * time.Hour),
+			Metadata:     acquiredMeta,
+		}).Error)
+
+		// Create a transfer event from owner1 to owner2
+		blockNum := uint64(200)
+		transferEvent := schema.ProvenanceEvent{
+			TokenID:     token.ID,
+			Chain:       domain.ChainEthereumMainnet,
+			EventType:   schema.ProvenanceEventTypeTransfer,
+			FromAddress: &owner1,
+			ToAddress:   &owner2,
+			Quantity:    types.StringPtr("1"),
+			TxHash:      types.StringPtr("0xtransferhash555"),
+			BlockNumber: &blockNum,
+			Timestamp:   time.Now().UTC(),
+		}
+		require.NoError(t, setupTx.Create(&transferEvent).Error)
+
+		// Remove released/acquired rows for the transfer so workers start from empty log for *this transfer*
+		require.NoError(t, setupTx.WithContext(ctx).
+			Where("token_id = ? AND event_type IN ? AND (metadata->>'tx_hash') = ?", token.ID, []string{
+				string(schema.EventTypeAcquired),
+				string(schema.EventTypeReleased),
+			}, "0xtransferhash555").
+			Delete(&schema.TokenEvent{}).Error)
+
+		require.NoError(t, setupTx.Commit().Error)
+
+		t.Cleanup(func() {
+			_ = testDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+				if err := tx.Where("token_id = ?", token.ID).Delete(&schema.TokenEvent{}).Error; err != nil {
+					return err
+				}
+				if err := tx.Where("token_id = ?", token.ID).Delete(&schema.ProvenanceEvent{}).Error; err != nil {
+					return err
+				}
+				if err := tx.Where("token_id = ?", token.ID).Delete(&schema.Balance{}).Error; err != nil {
+					return err
+				}
+				return tx.Where("id = ?", token.ID).Delete(&schema.Token{}).Error
+			})
+		})
+
+		const workers = 24
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		errs := make(chan error, workers)
+
+		for range workers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs <- testDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+					return pg.updateOwnershipPeriods(ctx, tx, &transferEvent, domain.StandardERC721)
+				})
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			require.NoError(t, err)
+		}
+
+		var releasedCount int64
+		require.NoError(t, testDB.WithContext(ctx).
+			Model(&schema.TokenEvent{}).
+			Where("token_id = ? AND owner_address = ? AND event_type = ?",
+				token.ID, owner1, schema.EventTypeReleased).
+			Count(&releasedCount).Error)
+
+		assert.Equal(t, int64(1), releasedCount,
+			"concurrent updateOwnershipPeriods for the same transfer must leave exactly one released row")
+
+		var acquiredCount int64
+		require.NoError(t, testDB.WithContext(ctx).
+			Model(&schema.TokenEvent{}).
+			Where("token_id = ? AND owner_address = ? AND event_type = ?",
+				token.ID, owner2, schema.EventTypeAcquired).
+			Count(&acquiredCount).Error)
+
+		assert.Equal(t, int64(1), acquiredCount,
+			"concurrent updateOwnershipPeriods for the same transfer must leave exactly one acquired row for new owner")
 	})
 }
 
@@ -6184,6 +6491,7 @@ func RunStoreTests(t *testing.T, initDB func(t *testing.T) Store, cleanupDB func
 		fn   func(*testing.T, Store)
 	}{
 		{"CreateTokenMint", testCreateTokenMint},
+		{"OwnershipTokenEventIdempotency", testOwnershipTokenEventIdempotency},
 		{"UpdateTokenTransfer", testUpdateTokenTransfer},
 		{"UpdateTokenBurn", testUpdateTokenBurn},
 		{"CreateTokenWithProvenances", testCreateTokenWithProvenances},


### PR DESCRIPTION
## Problem

Concurrent token indexing could insert multiple `acquired`/`released` rows in `token_events` for the same transfer because deduplication relied on a check-then-insert pattern without a database uniqueness constraint. That produced duplicate ownership history in collection sync.

Fixes #46

## Why It Matters

Collection sync and provenance views depend on `token_events` as a calm, accurate ownership log. Duplicate `acquired` rows break that contract and make owner history unreliable under concurrent workers or retries.

## Acceptance Checks

- [x] Migration `017.sql` deduplicates existing ownership rows and adds `token_events_ownership_unique`
- [x] Fresh schema in `init_pg_db.sql` includes the same partial unique index
- [x] `createTokenEvent` uses `ON CONFLICT DO NOTHING` for ownership rows with `metadata.tx_hash`
- [x] App fails fast if migration 017 has not been applied (no pre-migration fallback)
- [x] Store tests cover mint retry, same-tx batch ingestion, and concurrent acquired/released races
- [x] `CGO_ENABLED=1 go test -count=1 ./internal/store/...` passes locally

## Human Owner

@jollyjoker992

## How The Agent Will Be Used

Agent implemented the migration, store idempotency path, regression tests, and deployment-order documentation after investigating issue #46 and addressing review feedback.

## PR or Deploy Link

N/A (this PR)

## Deployment notes

**Run migration 017 before deploying this app version.** The code depends on `token_events_ownership_unique`; deploying first will cause ownership event inserts to fail with PostgreSQL `42P10`. See `DEVELOPMENT.md` for verification commands.