### PR TITLE
refactor(migrations): split dedup into batched script with traffic pause

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -187,11 +187,46 @@ Some migrations introduce database constraints that application code depends on 
 
 This migration adds the `token_events_ownership_unique` partial index that application code depends on for idempotent ownership event insertion.
 
+**⚠️ CRITICAL: Traffic must be paused for migration 017**
+
+Unlike most migrations, **you MUST pause or stop write traffic** before running migration 017. This is required because:
+
+1. **Race condition risk**: If writes continue between dedup (`017_dedup.sql`) and unique index creation (`017.sql`), new duplicates can be introduced, causing the unique index creation to fail.
+2. **Write blocking**: `CREATE UNIQUE INDEX` (non-concurrent) in `017.sql` blocks writes during index build on large tables.
+
+**Deployment sequence for migration 017:**
+
+1. **STOP write traffic** (pause indexer workers, drain queues, or use maintenance mode)
+2. Run `017_dedup.sql` if `token_events` is large or has known duplicates
+3. Run `017.sql` immediately after dedup completes
+4. Verify index exists (see verification commands below)
+5. Deploy new application version
+6. **RESUME write traffic**
+
+**Large databases (recommended when `token_events` has many rows or known duplicates):**
+
+Run the batched dedup script **before** `017.sql`. It deletes duplicate `acquired`/`released` rows in batches (default 50,000 per batch) and `COMMIT`s between batches so one huge `DELETE` does not hold locks for the full table scan.
+
+```bash
+# 1. Batched dedup (no wrapping BEGIN; commits per batch)
+psql -h localhost -U postgres -d ff_indexer -f db/migrations/017_dedup.sql
+
+# 2. Unique index (transactional)
+psql -h localhost -U postgres -d ff_indexer -f db/migrations/017.sql
+```
+
+**IMPORTANT:** `017_dedup.sql` performs its own transaction control (`COMMIT` per batch). Migration runners that auto-wrap files in `BEGIN`/`COMMIT` transactions must disable that wrapping for this file, or the procedure will fail.
+
+**Small databases or fresh installs:**
+
+Fresh installs from `init_pg_db.sql` can run `017.sql` directly if there are no duplicate ownership rows. Traffic pause is still required due to write blocking during index build.
+
 - **If migration has NOT run:** Application will fail at runtime with PostgreSQL error:
   ```
   ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10)
   ```
 - **If app deploys before migration:** All ownership event inserts will fail, breaking token indexing
+- **If `017.sql` runs before dedup when duplicates exist:** `CREATE UNIQUE INDEX` fails; run `017_dedup.sql` then retry `017.sql`
 - **There is NO fallback:** The application will explicitly fail to prevent data corruption
 
 **Migration verification:**
@@ -205,6 +240,16 @@ SELECT indexname, indexdef
 FROM pg_indexes 
 WHERE tablename = 'token_events' 
   AND indexname = 'token_events_ownership_unique';
+
+# Optional: confirm no duplicate ownership keys remain
+SELECT token_id, owner_address, event_type, metadata->>'tx_hash' AS tx_hash, COUNT(*) AS n
+FROM token_events
+WHERE event_type IN ('acquired', 'released')
+  AND owner_address IS NOT NULL
+  AND metadata->>'tx_hash' IS NOT NULL
+GROUP BY 1, 2, 3, 4
+HAVING COUNT(*) > 1
+LIMIT 5;
 ```
 
 **For production deployments:**

--- a/db/migrations/017.sql
+++ b/db/migrations/017.sql
@@ -1,31 +1,26 @@
--- Migration 017: Deduplicate ownership token_events and enforce per-transfer uniqueness
+-- Migration 017: Enforce per-transfer uniqueness on ownership token_events
 -- See https://github.com/feral-file/ff-indexer-v2/issues/46
 --
 -- ⚠️ CRITICAL: This migration MUST be applied BEFORE deploying application code that depends on it.
 -- The application uses ON CONFLICT with token_events_ownership_unique and will fail at runtime
 -- if this index does not exist. There is no fallback behavior.
 --
+-- ⚠️ CRITICAL: You MUST pause or stop write traffic before running this migration.
+-- Reasons:
+--   1. CREATE UNIQUE INDEX (non-concurrent) blocks writes during index build on large tables.
+--   2. If writes continue between 017_dedup.sql and this file, new duplicates can cause index creation to fail.
+--
 -- Deployment sequence:
---   1. Run this migration on all database instances
---   2. Verify the index exists (see DEVELOPMENT.md for verification commands)
---   3. Deploy the new application version
+--   1. STOP write traffic (pause indexer workers, drain queues)
+--   2. If token_events is large or has known duplicates, run 017_dedup.sql first (batched deletes)
+--   3. Run this file (creates token_events_ownership_unique)
+--   4. Verify the index exists (see DEVELOPMENT.md)
+--   5. Deploy the new application version
+--   6. RESUME write traffic
+--
+-- Deduplication is NOT inlined here: see 017_dedup.sql for a batched, commit-per-batch backfill.
 
 BEGIN;
-
--- Remove duplicate acquired/released rows that share token, owner, event type, and tx_hash.
--- Keep the earliest row (lowest id) as the canonical record.
-DELETE FROM token_events te
-WHERE te.event_type IN ('acquired', 'released')
-  AND te.owner_address IS NOT NULL
-  AND te.metadata->>'tx_hash' IS NOT NULL
-  AND te.id NOT IN (
-      SELECT MIN(id)
-      FROM token_events
-      WHERE event_type IN ('acquired', 'released')
-        AND owner_address IS NOT NULL
-        AND metadata->>'tx_hash' IS NOT NULL
-      GROUP BY token_id, owner_address, event_type, metadata->>'tx_hash'
-  );
 
 CREATE UNIQUE INDEX token_events_ownership_unique
 ON token_events (token_id, owner_address, event_type, (metadata->>'tx_hash'))

--- a/db/migrations/017_dedup.sql
+++ b/db/migrations/017_dedup.sql
@@ -1,0 +1,83 @@
+-- Migration 017 dedup (run BEFORE 017.sql on large databases)
+-- See https://github.com/feral-file/ff-indexer-v2/issues/46
+--
+-- Removes duplicate acquired/released token_events, keeping the row with the lowest id
+-- per (token_id, owner_address, event_type, metadata.tx_hash).
+--
+-- ⚠️ CRITICAL: You MUST pause or stop write traffic before running this migration.
+-- If writes continue between this dedup and 017.sql's unique index creation, new duplicates
+-- can be introduced, causing the unique index creation to fail.
+--
+-- Why a separate script:
+--   - The NOT IN (SELECT MIN(id) ... GROUP BY) pattern does not scale to millions of rows.
+--   - This script deletes in batches and COMMITs between batches to limit lock duration and WAL.
+--
+-- How to run (must be OUTSIDE an explicit BEGIN transaction):
+--   1. STOP write traffic (pause indexer workers, drain queues)
+--   2. psql ... -f db/migrations/017_dedup.sql
+--   3. psql ... -f db/migrations/017.sql (immediately after)
+--   4. Deploy new application version
+--   5. RESUME write traffic
+--
+-- IMPORTANT: This script does its own transaction control (COMMIT per batch).
+-- Migration runners that auto-wrap files in BEGIN/COMMIT must disable that wrapping for this file.
+--
+-- Safe to re-run: later batches delete zero rows and the procedure exits.
+
+-- Supporting index for the duplicate-finding join (dropped at the end of this script).
+-- CONCURRENTLY avoids blocking writes during index build on large tables.
+--
+-- Drop invalid index from prior interrupted concurrent build (reruns must not skip creation).
+DROP INDEX CONCURRENTLY IF EXISTS idx_token_events_ownership_dedup_tmp;
+
+CREATE INDEX CONCURRENTLY idx_token_events_ownership_dedup_tmp
+ON token_events (token_id, owner_address, event_type, (metadata->>'tx_hash'), id)
+WHERE event_type IN ('acquired', 'released')
+  AND owner_address IS NOT NULL
+  AND (metadata->>'tx_hash') IS NOT NULL;
+
+CREATE OR REPLACE PROCEDURE migration_017_dedup_token_events(p_batch_size bigint DEFAULT 50000)
+LANGUAGE plpgsql
+AS $proc$
+DECLARE
+    v_deleted bigint;
+BEGIN
+    IF p_batch_size < 1 THEN
+        RAISE EXCEPTION 'p_batch_size must be >= 1';
+    END IF;
+
+    LOOP
+        -- Delete rows that have an older sibling with the same ownership key (keep MIN(id)).
+        -- DISTINCT prevents fanout when a newer row joins multiple older rows.
+        WITH dup_ids AS (
+            SELECT DISTINCT newer.id
+            FROM token_events AS newer
+            INNER JOIN token_events AS older
+                ON older.token_id = newer.token_id
+               AND older.owner_address = newer.owner_address
+               AND older.event_type = newer.event_type
+               AND older.metadata->>'tx_hash' = newer.metadata->>'tx_hash'
+               AND older.id < newer.id
+            WHERE newer.event_type IN ('acquired', 'released')
+              AND newer.owner_address IS NOT NULL
+              AND newer.metadata->>'tx_hash' IS NOT NULL
+            LIMIT p_batch_size
+        )
+        DELETE FROM token_events AS t
+        USING dup_ids AS d
+        WHERE t.id = d.id;
+
+        GET DIAGNOSTICS v_deleted = ROW_COUNT;
+        RAISE NOTICE 'migration_017_dedup: deleted % duplicate ownership token_events', v_deleted;
+        COMMIT;
+        EXIT WHEN v_deleted = 0;
+    END LOOP;
+END;
+$proc$;
+
+CALL migration_017_dedup_token_events();
+
+DROP PROCEDURE migration_017_dedup_token_events;
+
+-- CONCURRENTLY avoids blocking writes during index drop.
+DROP INDEX CONCURRENTLY IF EXISTS idx_token_events_ownership_dedup_tmp;


### PR DESCRIPTION
## Summary

Refactors migration 017 to improve operational safety and performance for production deployment on large databases.

### Key Changes

1. **Split deduplication into separate batched script (`017_dedup.sql`)**:
   - Removes duplicate `acquired`/`released` token_events in batches (default 50k per batch)
   - Commits between batches to limit lock duration and WAL growth
   - Creates temporary helper index with `CONCURRENTLY` to avoid blocking writes
   - Uses `DISTINCT` in self-join to prevent ID fanout
   - Handles invalid indexes from interrupted concurrent builds
   - Safe to re-run: exits after first zero-delete iteration

2. **Simplify `017.sql` to only create unique index**:
   - Removes inline `DELETE ... NOT IN (SELECT MIN(id) ...)` which doesn't scale to millions of rows
   - Only creates `token_events_ownership_unique` index
   - Transactional and deterministic

3. **Document mandatory traffic pause**:
   - Add critical warnings in `DEVELOPMENT.md`, `017_dedup.sql`, and `017.sql`
   - Explain race condition risk: writes between dedup and unique index creation can introduce new duplicates
   - Explain write blocking: non-concurrent `CREATE UNIQUE INDEX` blocks writes during build
   - Provide explicit 6-step deployment sequence

### Migration Sequence

For production deployments:

1. **STOP write traffic** (pause indexer workers, drain queues)
2. Run `017_dedup.sql` if `token_events` is large or has known duplicates
3. Run `017.sql` immediately after dedup completes
4. Verify index exists
5. Deploy new application version
6. **RESUME write traffic**

Fresh installs can run `017.sql` directly but still need traffic pause due to write blocking.

### Performance Benefits

- Batched deletes reduce lock contention and resource usage
- `CREATE INDEX CONCURRENTLY` avoids blocking writes during helper index build
- `DISTINCT` prevents fanout when a row joins multiple older rows
- `id` as trailing index key improves join/delete locality

### Operational Safety

- Invalid index handling: explicit DROP before CREATE ensures reruns work correctly
- Transaction-wrapping compatibility: documents requirement to disable auto-wrapping for `017_dedup.sql`
- Race condition eliminated: mandatory traffic pause prevents new duplicates during migration
- Write blocking documented: operators know to expect downtime during index creation

## Test Plan

- [x] All store tests pass including concurrent ownership idempotency tests
- [x] Linter checks pass on modified files
- [x] Reviewer subagent accepted the approach with no blocking issues

## Validation Status

- [x] Implementation complete
- [x] Tests pass
- [x] Documentation updated (`DEVELOPMENT.md`, migration scripts)
- [x] Review complete (3 iterations with reviewer subagent)

## Related Issues

Addresses reviewer feedback on #90 (merged)
Related to #46

## Notes

This refactor builds on the fix merged in #90. The original inline deduplication approach worked but was identified as inefficient for large production databases during post-merge review.

The new batched approach with traffic pause requirement provides better operational safety and performance for databases with millions of `token_events` records.