### PR TITLE
fix(api): health-aware display URLs and WorkingURL propagation (#96)

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -150,7 +150,11 @@ type MediaAsset {
   updated_at: Time!
 }
 
-# Unified token display data (merges metadata and enrichment source)
+# Unified token display data: merges metadata and enrichment source (enrichment takes precedence),
+# then applies per-field health filtering via token_media_health. For each URL field
+# (animation_url, image_url), only a URL with a "healthy" health row is returned; "broken" and
+# "unknown" rows suppress the URL. If no health rows exist yet for a field's source groups the
+# raw merged value for that field is returned unchanged.
 type TokenDisplay {
   image_url: String
   animation_url: String

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -1392,7 +1392,13 @@ components:
           anyOf:
             - $ref: '#/components/schemas/TokenDisplayResponse'
             - type: "null"
-          description: Unified display field merging metadata and enrichment source (requires display expansion). Enrichment source takes precedence over metadata when both have the same field.
+          description: |
+            Unified display field (requires `display` expansion). Merges metadata and enrichment
+            source (enrichment takes precedence), then applies per-field health filtering via
+            `token_media_health`: for each URL field (`animation_url`, `image_url`), only a URL
+            with a `healthy` health row is returned; `broken` and `unknown` rows suppress the
+            field. If no health rows exist yet for a field's source groups, the raw merged value
+            for that field is returned unchanged.
         media_assets:
           anyOf:
             - type: array
@@ -1400,14 +1406,14 @@ components:
                 $ref: '#/components/schemas/MediaAssetResponse'
             - type: "null"
           description: |
-            Unified media assets array (requires media_asset expansion).
+            Unified media assets array (requires `media_asset` expansion).
             
             Content depends on which other expansions are requested:
             - With `metadata`: includes media assets from metadata
             - With `enrichment_source`: includes media assets from enrichment source  
-            - With `display`: includes only media assets for URLs in the merged display field
+            - With `display`: includes media assets for the health-filtered display URLs only
             - With `metadata` + `enrichment_source`: includes media from both sources
-            - With `metadata` + `display`: includes media from metadata + display merged URLs
+            - With `metadata` + `display`: includes media from metadata + health-filtered display URLs
             - Without any source expansion: returns empty array
 
     TokenMetadataResponse:
@@ -1507,21 +1513,33 @@ components:
     TokenDisplayResponse:
       type: object
       description: |
-        Unified token display data that merges metadata and enrichment source.
-        Enrichment source takes precedence over metadata when both have the same field.
+        Unified token display data: merges metadata and enrichment source (enrichment takes
+        precedence), then applies per-field health filtering via `token_media_health`.
         
-        This field is populated when the `display` expansion is requested.
-        When `display` is requested without explicit `metadata` or `enrichment_source` expansions,
-        the individual metadata and enrichment_source fields will be null (cleaned up),
-        but their data is merged into this display field.
+        For each URL field (`animation_url`, `image_url`), only a URL with a `healthy` health row
+        is returned; `broken` and `unknown` (unverified) rows suppress the field. If no health
+        rows exist yet for a field's source groups, the raw merged value for that field is returned
+        unchanged (filtering is per-field — an `image_url` health row does not affect
+        `animation_url` pass-through and vice versa).
+        
+        Populated when the `display` expansion is requested. When `display` is requested without
+        explicit `metadata` or `enrichment_source` expansions, those fields are null in the
+        response but their data is merged (and health-filtered) into this display field.
       properties:
         image_url:
           type: [string, "null"]
-          description: Primary image URL (from enrichment source if available, otherwise from metadata)
+          description: |
+            Primary image URL after merge and health filtering. Precedence: enrichment-image if
+            healthy, else metadata-image if healthy, else omitted (`null`) when health rows exist
+            but none are `healthy`. Raw merged value returned when no image health rows exist yet.
           example: "https://example.com/image.png"
         animation_url:
           type: [string, "null"]
-          description: Animation/video URL (from enrichment source if available, otherwise from metadata)
+          description: |
+            Animation/video URL after merge and health filtering. Precedence: enrichment-animation
+            if healthy, else metadata-animation if healthy, else omitted (`null`) when health rows
+            exist but none are `healthy`. Raw merged value returned when no animation health rows
+            exist yet.
           example: "https://example.com/animation.mp4"
         name:
           type: [string, "null"]

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -1515,13 +1515,13 @@ components:
       description: |
         Unified token display data: merges metadata and enrichment source (enrichment takes
         precedence), then applies per-field health filtering via `token_media_health`.
-        
+
         For each URL field (`animation_url`, `image_url`), only a URL with a `healthy` health row
         is returned; `broken` and `unknown` (unverified) rows suppress the field. If no health
         rows exist yet for a field's source groups, the raw merged value for that field is returned
         unchanged (filtering is per-field — an `image_url` health row does not affect
         `animation_url` pass-through and vice versa).
-        
+
         Populated when the `display` expansion is requested. When `display` is requested without
         explicit `metadata` or `enrichment_source` expansions, those fields are null in the
         response but their data is merged (and health-filtered) into this display field.

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -102,15 +102,18 @@ paths:
         - `owners` - Include paginated owner information
         - `provenance_events` - Include paginated provenance events
         - `enrichment_source` - Include vendor enrichment data
-        - `display` - Include unified display field (merges metadata and enrichment source, with enrichment taking precedence)
+        - `display` - Include unified display field. Merges metadata and enrichment source (enrichment
+          takes precedence), then applies health filtering: only URLs whose `token_media_health` row is
+          `healthy` are returned. URLs with `broken` or `unknown` (unverified) status are omitted.
+          If no health rows exist yet for a token the raw merged value is returned unchanged.
         - `media_asset` - Include media assets based on requested expansions
         
         **Note**: The `media_asset` expansion behavior depends on other requested expansions:
         - With `metadata` only: includes media assets from metadata
         - With `enrichment_source` only: includes media assets from enrichment source
-        - With `display` only: includes media assets for URLs in the merged display (respects enrichment precedence)
+        - With `display` only: includes media assets for the health-filtered display URLs only
         - With `metadata` + `enrichment_source`: includes media assets from both sources
-        - With `metadata` + `display`: includes media from metadata + display merged URLs
+        - With `metadata` + `display`: includes media from metadata + health-filtered display URLs
         - Without any source expansion: returns empty array
         
         ## Sub-resource Pagination
@@ -258,16 +261,19 @@ paths:
         - `owners` - Include owner information (first 20 items per token)
         - `provenance_events` - Include provenance events (first 20 items per token, ordered by timestamp DESC)
         - `enrichment_source` - Include vendor enrichment data
-        - `display` - Include unified display field (merges metadata and enrichment source, with enrichment taking precedence)
+        - `display` - Include unified display field. Merges metadata and enrichment source (enrichment
+          takes precedence), then applies health filtering: only URLs whose `token_media_health` row is
+          `healthy` are returned. URLs with `broken` or `unknown` (unverified) status are omitted.
+          If no health rows exist yet for a token the raw merged value is returned unchanged.
         - `media_asset` - Include media assets based on requested expansions
         - `owner_provenances` - Include owner provenance history (fixed page size per token; not available on GET /tokens/{cid})
         
         **Note**: The `media_asset` expansion behavior depends on other requested expansions:
         - With `metadata` only: includes media assets from metadata
         - With `enrichment_source` only: includes media assets from enrichment source
-        - With `display` only: includes media assets for URLs in the merged display (respects enrichment precedence)
+        - With `display` only: includes media assets for the health-filtered display URLs only
         - With `metadata` + `enrichment_source`: includes media assets from both sources
-        - With `metadata` + `display`: includes media from metadata + display merged URLs
+        - With `metadata` + `display`: includes media from metadata + health-filtered display URLs
         - Without any source expansion: returns empty array
         
         **Important**: For list queries, `owners` and `provenance_events` return a fixed cap of items per token. Use `GET /api/v1/tokens/{cid}` for paginated owners and provenance events.

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -103,9 +103,12 @@ paths:
         - `provenance_events` - Include paginated provenance events
         - `enrichment_source` - Include vendor enrichment data
         - `display` - Include unified display field. Merges metadata and enrichment source (enrichment
-          takes precedence), then applies health filtering: only URLs whose `token_media_health` row is
-          `healthy` are returned. URLs with `broken` or `unknown` (unverified) status are omitted.
-          If no health rows exist yet for a token the raw merged value is returned unchanged.
+          takes precedence), then applies health filtering per media-source group: for each URL field
+          (`animation_url`, `image_url`), only a URL whose `token_media_health` row is `healthy` is
+          returned. URLs with `broken` or `unknown` (unverified) status are omitted. If no health rows
+          exist yet for a given field's source groups the raw merged value for that field is returned
+          unchanged (i.e. filtering is per-field, not token-wide — an `image_url` health row does not
+          affect `animation_url` pass-through and vice versa).
         - `media_asset` - Include media assets based on requested expansions
         
         **Note**: The `media_asset` expansion behavior depends on other requested expansions:
@@ -262,9 +265,12 @@ paths:
         - `provenance_events` - Include provenance events (first 20 items per token, ordered by timestamp DESC)
         - `enrichment_source` - Include vendor enrichment data
         - `display` - Include unified display field. Merges metadata and enrichment source (enrichment
-          takes precedence), then applies health filtering: only URLs whose `token_media_health` row is
-          `healthy` are returned. URLs with `broken` or `unknown` (unverified) status are omitted.
-          If no health rows exist yet for a token the raw merged value is returned unchanged.
+          takes precedence), then applies health filtering per media-source group: for each URL field
+          (`animation_url`, `image_url`), only a URL whose `token_media_health` row is `healthy` is
+          returned. URLs with `broken` or `unknown` (unverified) status are omitted. If no health rows
+          exist yet for a given field's source groups the raw merged value for that field is returned
+          unchanged (i.e. filtering is per-field, not token-wide — an `image_url` health row does not
+          affect `animation_url` pass-through and vice versa).
         - `media_asset` - Include media assets based on requested expansions
         - `owner_provenances` - Include owner provenance history (fixed page size per token; not available on GET /tokens/{cid})
         

--- a/internal/api/graphql/generated.go
+++ b/internal/api/graphql/generated.go
@@ -1694,7 +1694,11 @@ type MediaAsset {
   updated_at: Time!
 }
 
-# Unified token display data (merges metadata and enrichment source)
+# Unified token display data: merges metadata and enrichment source (enrichment takes precedence),
+# then applies per-field health filtering via token_media_health. For each URL field
+# (animation_url, image_url), only a URL with a "healthy" health row is returned; "broken" and
+# "unknown" rows suppress the URL. If no health rows exist yet for a field's source groups the
+# raw merged value for that field is returned unchanged.
 type TokenDisplay {
   image_url: String
   animation_url: String

--- a/internal/api/shared/dto/token_display_health.go
+++ b/internal/api/shared/dto/token_display_health.go
@@ -18,8 +18,10 @@ import "github.com/feral-file/ff-indexer-v2/internal/store/schema"
 // Constraints:
 //   - If healthRows is empty (no rows yet probed) the display is returned unchanged so tokens
 //     that have never been health-checked are not silently hidden.
-//   - Only rows with health_status = "broken" are filtered out; "unknown" rows are kept to
-//     avoid hiding tokens whose URLs have not been checked yet.
+//   - Only URLs whose health row is explicitly "healthy" are served. Both "broken" and "unknown"
+//     rows suppress the URL. "unknown" rows are treated as unconfirmed — returning an unverified
+//     URL would be a false positive, because the health state is indeterminate and the URL may
+//     well be broken. A URL is only surfaced once the health probe has confirmed it is reachable.
 func ApplyHealthyMediaURLs(display *TokenDisplayResponse, healthRows []schema.TokenMediaHealth) *TokenDisplayResponse {
 	if display == nil {
 		return nil
@@ -60,11 +62,12 @@ func ApplyHealthyMediaURLs(display *TokenDisplayResponse, healthRows []schema.To
 			metaURL := urlBySource[schema.MediaHealthSourceMetadataAnimation]
 			out.AnimationURL = &metaURL
 		default:
-			// All known animation URLs are broken — omit rather than serve a dead URL.
+			// No confirmed-healthy animation URL found. This covers both "broken" (known dead)
+			// and "unknown" (not yet probed) — omit rather than serve an unverified URL.
 			out.AnimationURL = nil
 		}
 	}
-	// If no animation health rows exist, keep the merged value unchanged (unchecked).
+	// If no animation health rows exist at all, keep the merged value unchanged (unchecked).
 
 	// --- image_url ---
 	// Precedence: enrichment-image > metadata-image > nil

--- a/internal/api/shared/dto/token_display_health.go
+++ b/internal/api/shared/dto/token_display_health.go
@@ -1,0 +1,88 @@
+package dto
+
+import "github.com/feral-file/ff-indexer-v2/internal/store/schema"
+
+// ApplyHealthyMediaURLs filters the display URLs produced by MergeTokenDisplay against the
+// token's known health rows so the API never returns a URL that is broken.
+//
+// Reason: MergeTokenDisplay is a pure metadata/enrichment merge with no health knowledge.
+// A token can be viewable=true while animation_url points to a dead gateway (e.g. an IPFS
+// gateway that returned 404 after the token was indexed). FF1 loads animation_url first for
+// generative works, so this causes black-screen regressions (#96).
+//
+// Selection rule (mirrors MergeTokenDisplay precedence):
+//   - animation_url: prefer enrichment-animation if healthy; else metadata-animation if healthy;
+//     else nil (omit the field — do not serve a broken URL).
+//   - image_url: same for image sources.
+//
+// Constraints:
+//   - If healthRows is empty (no rows yet probed) the display is returned unchanged so tokens
+//     that have never been health-checked are not silently hidden.
+//   - Only rows with health_status = "broken" are filtered out; "unknown" rows are kept to
+//     avoid hiding tokens whose URLs have not been checked yet.
+func ApplyHealthyMediaURLs(display *TokenDisplayResponse, healthRows []schema.TokenMediaHealth) *TokenDisplayResponse {
+	if display == nil {
+		return nil
+	}
+	// No health data yet: return unchanged so unchecked tokens are still visible.
+	if len(healthRows) == 0 {
+		return display
+	}
+
+	// Index rows by source for O(1) lookup.
+	type healthKey = schema.MediaHealthSource
+	statusBySource := make(map[healthKey]schema.MediaHealthStatus, len(healthRows))
+	urlBySource := make(map[healthKey]string, len(healthRows))
+	for _, row := range healthRows {
+		// When a source has multiple rows (shouldn't happen in normal operation, but
+		// possible during propagation windows), prefer healthy over broken.
+		existing, seen := statusBySource[row.MediaSource]
+		if !seen || (existing != schema.MediaHealthStatusHealthy && row.HealthStatus == schema.MediaHealthStatusHealthy) {
+			statusBySource[row.MediaSource] = row.HealthStatus
+			urlBySource[row.MediaSource] = row.MediaURL
+		}
+	}
+
+	out := *display // shallow copy — we only replace pointer fields
+
+	// --- animation_url ---
+	// Precedence: enrichment-animation > metadata-animation > nil
+	enrichAnimStatus, hasEnrichAnim := statusBySource[schema.MediaHealthSourceEnrichmentAnimation]
+	metaAnimStatus, hasMetaAnim := statusBySource[schema.MediaHealthSourceMetadataAnimation]
+
+	if hasEnrichAnim || hasMetaAnim {
+		// At least one animation health row exists: apply health filtering.
+		switch {
+		case hasEnrichAnim && enrichAnimStatus == schema.MediaHealthStatusHealthy:
+			enrichURL := urlBySource[schema.MediaHealthSourceEnrichmentAnimation]
+			out.AnimationURL = &enrichURL
+		case hasMetaAnim && metaAnimStatus == schema.MediaHealthStatusHealthy:
+			metaURL := urlBySource[schema.MediaHealthSourceMetadataAnimation]
+			out.AnimationURL = &metaURL
+		default:
+			// All known animation URLs are broken — omit rather than serve a dead URL.
+			out.AnimationURL = nil
+		}
+	}
+	// If no animation health rows exist, keep the merged value unchanged (unchecked).
+
+	// --- image_url ---
+	// Precedence: enrichment-image > metadata-image > nil
+	enrichImgStatus, hasEnrichImg := statusBySource[schema.MediaHealthSourceEnrichmentImage]
+	metaImgStatus, hasMetaImg := statusBySource[schema.MediaHealthSourceMetadataImage]
+
+	if hasEnrichImg || hasMetaImg {
+		switch {
+		case hasEnrichImg && enrichImgStatus == schema.MediaHealthStatusHealthy:
+			enrichURL := urlBySource[schema.MediaHealthSourceEnrichmentImage]
+			out.ImageURL = &enrichURL
+		case hasMetaImg && metaImgStatus == schema.MediaHealthStatusHealthy:
+			metaURL := urlBySource[schema.MediaHealthSourceMetadataImage]
+			out.ImageURL = &metaURL
+		default:
+			out.ImageURL = nil
+		}
+	}
+
+	return &out
+}

--- a/internal/api/shared/dto/token_display_health_test.go
+++ b/internal/api/shared/dto/token_display_health_test.go
@@ -1,0 +1,254 @@
+package dto_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/feral-file/ff-indexer-v2/internal/api/shared/dto"
+	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
+)
+
+// ptr is a helper to get a pointer to a string literal.
+func ptr(s string) *string { return &s }
+
+// buildHealthRow is a test helper.
+func buildHealthRow(tokenID uint64, source schema.MediaHealthSource, url string, status schema.MediaHealthStatus) schema.TokenMediaHealth {
+	return schema.TokenMediaHealth{
+		TokenID:      tokenID,
+		MediaURL:     url,
+		MediaSource:  source,
+		HealthStatus: status,
+	}
+}
+
+// ====================================================================================
+// ApplyHealthyMediaURLs – nil / empty guard
+// ====================================================================================
+
+func TestApplyHealthyMediaURLs_NilDisplay_ReturnsNil(t *testing.T) {
+	result := dto.ApplyHealthyMediaURLs(nil, nil)
+	assert.Nil(t, result)
+}
+
+func TestApplyHealthyMediaURLs_NoHealthRows_ReturnsUnchanged(t *testing.T) {
+	animURL := "https://ipfs.feralfile.com/ipfs/QmAnim"
+	imgURL := "https://ipfs.feralfile.com/ipfs/QmImg"
+	display := &dto.TokenDisplayResponse{
+		AnimationURL: ptr(animURL),
+		ImageURL:     ptr(imgURL),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, nil)
+
+	// No health rows yet: return unchanged so unchecked tokens are not silently hidden.
+	assert.Equal(t, display, result)
+}
+
+// ====================================================================================
+// ApplyHealthyMediaURLs – animation_url filtering
+// ====================================================================================
+
+// TestApplyHealthyMediaURLs_BrokenAnimation_NilsAnimationURL is the primary #96 scenario:
+// animation_url points to a dead gateway; the API must not return it.
+func TestApplyHealthyMediaURLs_BrokenAnimation_NilsAnimationURL(t *testing.T) {
+	animURL := "https://ipfs.feralfile.com/ipfs/QmAnim"
+	imgURL := "https://ipfs.filebase.io/ipfs/QmImg"
+	display := &dto.TokenDisplayResponse{
+		AnimationURL: ptr(animURL),
+		ImageURL:     ptr(imgURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceMetadataAnimation, animURL, schema.MediaHealthStatusBroken),
+		buildHealthRow(1, schema.MediaHealthSourceMetadataImage, imgURL, schema.MediaHealthStatusHealthy),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	assert.Nil(t, result.AnimationURL, "broken animation_url must be omitted")
+	assert.Equal(t, imgURL, *result.ImageURL, "healthy image_url must be kept")
+}
+
+func TestApplyHealthyMediaURLs_HealthyAnimation_Kept(t *testing.T) {
+	animURL := "https://ipfs.filebase.io/ipfs/QmAnim"
+	imgURL := "https://ipfs.filebase.io/ipfs/QmImg"
+	display := &dto.TokenDisplayResponse{
+		AnimationURL: ptr(animURL),
+		ImageURL:     ptr(imgURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceMetadataAnimation, animURL, schema.MediaHealthStatusHealthy),
+		buildHealthRow(1, schema.MediaHealthSourceMetadataImage, imgURL, schema.MediaHealthStatusHealthy),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	assert.Equal(t, animURL, *result.AnimationURL)
+	assert.Equal(t, imgURL, *result.ImageURL)
+}
+
+// TestApplyHealthyMediaURLs_EnrichmentAnimationHealthy_PreferredOverMetadata verifies
+// MergeTokenDisplay precedence is respected: enrichment animation beats metadata animation.
+func TestApplyHealthyMediaURLs_EnrichmentAnimationHealthy_PreferredOverMetadata(t *testing.T) {
+	enrichAnimURL := "https://cdn.example.com/enrichment-anim.mp4"
+	metaAnimURL := "https://ipfs.feralfile.com/ipfs/QmDeadMeta"
+	display := &dto.TokenDisplayResponse{
+		// MergeTokenDisplay would have set enrichment URL here already
+		AnimationURL: ptr(enrichAnimURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceEnrichmentAnimation, enrichAnimURL, schema.MediaHealthStatusHealthy),
+		buildHealthRow(1, schema.MediaHealthSourceMetadataAnimation, metaAnimURL, schema.MediaHealthStatusBroken),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	assert.Equal(t, enrichAnimURL, *result.AnimationURL)
+}
+
+// TestApplyHealthyMediaURLs_EnrichmentBroken_FallsBackToHealthyMetadata covers the case where
+// enrichment animation is broken but metadata animation is healthy.
+func TestApplyHealthyMediaURLs_EnrichmentBroken_FallsBackToHealthyMetadata(t *testing.T) {
+	enrichAnimURL := "https://cdn.example.com/broken-enrichment-anim.mp4"
+	metaAnimURL := "https://ipfs.filebase.io/ipfs/QmHealthyMeta"
+	display := &dto.TokenDisplayResponse{
+		// enrichment URL was picked by MergeTokenDisplay
+		AnimationURL: ptr(enrichAnimURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceEnrichmentAnimation, enrichAnimURL, schema.MediaHealthStatusBroken),
+		buildHealthRow(1, schema.MediaHealthSourceMetadataAnimation, metaAnimURL, schema.MediaHealthStatusHealthy),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	// Should fall back to the healthy metadata URL
+	assert.Equal(t, metaAnimURL, *result.AnimationURL)
+}
+
+// TestApplyHealthyMediaURLs_AllAnimationsBroken_NilsField ensures that when every known
+// animation health row is broken the field is omitted entirely.
+func TestApplyHealthyMediaURLs_AllAnimationsBroken_NilsField(t *testing.T) {
+	enrichAnimURL := "https://cdn.example.com/broken1.mp4"
+	metaAnimURL := "https://ipfs.feralfile.com/ipfs/QmBroken2"
+	display := &dto.TokenDisplayResponse{
+		AnimationURL: ptr(enrichAnimURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceEnrichmentAnimation, enrichAnimURL, schema.MediaHealthStatusBroken),
+		buildHealthRow(1, schema.MediaHealthSourceMetadataAnimation, metaAnimURL, schema.MediaHealthStatusBroken),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	assert.Nil(t, result.AnimationURL, "all broken animations must result in nil field")
+}
+
+// TestApplyHealthyMediaURLs_UnknownStatus_AnimationKept verifies that "unknown" status rows
+// do not suppress the URL — only "broken" rows suppress it.
+func TestApplyHealthyMediaURLs_UnknownStatus_AnimationKept(t *testing.T) {
+	animURL := "https://ipfs.feralfile.com/ipfs/QmUnchecked"
+	display := &dto.TokenDisplayResponse{
+		AnimationURL: ptr(animURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceMetadataAnimation, animURL, schema.MediaHealthStatusUnknown),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	// Unknown (not yet probed) means we have a row but it hasn't passed health check yet.
+	// We omit it because "unknown" is not "healthy" per the selection rule.
+	// This is consistent with not silently hiding tokens but also not serving unverified URLs.
+	assert.Nil(t, result.AnimationURL)
+}
+
+// ====================================================================================
+// ApplyHealthyMediaURLs – image_url filtering
+// ====================================================================================
+
+func TestApplyHealthyMediaURLs_BrokenImage_NilsImageURL(t *testing.T) {
+	imgURL := "https://ipfs.feralfile.com/ipfs/QmDeadImg"
+	display := &dto.TokenDisplayResponse{
+		ImageURL: ptr(imgURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceMetadataImage, imgURL, schema.MediaHealthStatusBroken),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	assert.Nil(t, result.ImageURL)
+}
+
+func TestApplyHealthyMediaURLs_EnrichmentImageHealthy_Preferred(t *testing.T) {
+	enrichImgURL := "https://cdn.example.com/enrichment-img.jpg"
+	metaImgURL := "https://ipfs.feralfile.com/ipfs/QmDeadMeta"
+	display := &dto.TokenDisplayResponse{
+		ImageURL: ptr(enrichImgURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceEnrichmentImage, enrichImgURL, schema.MediaHealthStatusHealthy),
+		buildHealthRow(1, schema.MediaHealthSourceMetadataImage, metaImgURL, schema.MediaHealthStatusBroken),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	assert.Equal(t, enrichImgURL, *result.ImageURL)
+}
+
+// ====================================================================================
+// ApplyHealthyMediaURLs – only image health rows exist (no animation rows)
+// ====================================================================================
+
+func TestApplyHealthyMediaURLs_NoAnimationRows_AnimationURLUntouched(t *testing.T) {
+	animURL := "https://example.com/unchecked-anim.mp4"
+	imgURL := "https://example.com/img.jpg"
+	display := &dto.TokenDisplayResponse{
+		AnimationURL: ptr(animURL),
+		ImageURL:     ptr(imgURL),
+	}
+
+	// Only image health row — no animation row at all
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceMetadataImage, imgURL, schema.MediaHealthStatusHealthy),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	// Animation URL unchanged because no health row exists for it
+	assert.Equal(t, animURL, *result.AnimationURL)
+	assert.Equal(t, imgURL, *result.ImageURL)
+}
+
+// ====================================================================================
+// ApplyHealthyMediaURLs – original display object is not mutated
+// ====================================================================================
+
+func TestApplyHealthyMediaURLs_DoesNotMutateInput(t *testing.T) {
+	animURL := "https://ipfs.feralfile.com/ipfs/QmAnim"
+	imgURL := "https://ipfs.filebase.io/ipfs/QmImg"
+	display := &dto.TokenDisplayResponse{
+		AnimationURL: ptr(animURL),
+		ImageURL:     ptr(imgURL),
+	}
+
+	rows := []schema.TokenMediaHealth{
+		buildHealthRow(1, schema.MediaHealthSourceMetadataAnimation, animURL, schema.MediaHealthStatusBroken),
+	}
+
+	result := dto.ApplyHealthyMediaURLs(display, rows)
+
+	// Result has nil animation URL
+	assert.Nil(t, result.AnimationURL)
+	// Original is unchanged
+	assert.Equal(t, animURL, *display.AnimationURL)
+}

--- a/internal/api/shared/dto/token_display_health_test.go
+++ b/internal/api/shared/dto/token_display_health_test.go
@@ -149,9 +149,11 @@ func TestApplyHealthyMediaURLs_AllAnimationsBroken_NilsField(t *testing.T) {
 	assert.Nil(t, result.AnimationURL, "all broken animations must result in nil field")
 }
 
-// TestApplyHealthyMediaURLs_UnknownStatus_AnimationKept verifies that "unknown" status rows
-// do not suppress the URL — only "broken" rows suppress it.
-func TestApplyHealthyMediaURLs_UnknownStatus_AnimationKept(t *testing.T) {
+// TestApplyHealthyMediaURLs_UnknownStatus_AnimationOmitted verifies that "unknown" health rows
+// suppress the URL just like "broken" rows do. A URL is only surfaced once the health probe has
+// confirmed it is reachable (health_status = "healthy"). Returning an unverified URL would be a
+// false positive — the URL may be broken and FF1 would render a black screen.
+func TestApplyHealthyMediaURLs_UnknownStatus_AnimationOmitted(t *testing.T) {
 	animURL := "https://ipfs.feralfile.com/ipfs/QmUnchecked"
 	display := &dto.TokenDisplayResponse{
 		AnimationURL: ptr(animURL),
@@ -163,10 +165,7 @@ func TestApplyHealthyMediaURLs_UnknownStatus_AnimationKept(t *testing.T) {
 
 	result := dto.ApplyHealthyMediaURLs(display, rows)
 
-	// Unknown (not yet probed) means we have a row but it hasn't passed health check yet.
-	// We omit it because "unknown" is not "healthy" per the selection rule.
-	// This is consistent with not silently hiding tokens but also not serving unverified URLs.
-	assert.Nil(t, result.AnimationURL)
+	assert.Nil(t, result.AnimationURL, "unverified (unknown) animation URL must be omitted from display")
 }
 
 // ====================================================================================

--- a/internal/api/shared/executor/executor.go
+++ b/internal/api/shared/executor/executor.go
@@ -386,6 +386,25 @@ func (e *executor) GetTokens(ctx context.Context, owners []string, chains []doma
 		}
 	}
 
+	// Pre-compute health-filtered display URLs and add them to the bulk source URL set.
+	// ApplyHealthyMediaURLs reads the URL directly from token_media_health.media_url, which can
+	// diverge from raw metadata/enrichment URLs during the narrow window between a propagation
+	// transaction commit and the metadata bulk read (two separate queries, no shared snapshot).
+	// Adding display URLs here ensures GetMediaAssetsBySourceURLs includes them so that
+	// collectMediaAssetDTOsFromMap can satisfy the display+media_asset contract.
+	// The per-token loop re-runs MergeTokenDisplay+ApplyHealthyMediaURLs cheaply (no extra DB calls).
+	if expansionMap[types.ExpansionDisplay] && expansionMap[types.ExpansionMediaAsset] {
+		for _, token := range tokens {
+			metaDTO := dto.MapTokenMetadataToDTO(bulkMetadata[token.ID])
+			enrichDTO := dto.MapEnrichmentSourceToDTO(bulkEnrichmentSources[token.ID])
+			preDisplay := dto.MergeTokenDisplay(metaDTO, enrichDTO)
+			preDisplay = dto.ApplyHealthyMediaURLs(preDisplay, bulkMediaHealth[token.ID])
+			if preDisplay != nil {
+				allMediaSourceURLs = append(allMediaSourceURLs, preDisplay.MediaURLs()...)
+			}
+		}
+	}
+
 	// Fetch media assets in bulk if needed
 	var mediaAssetsMap map[string]schema.MediaAsset
 	if len(allMediaSourceURLs) > 0 {
@@ -995,6 +1014,19 @@ func (e *executor) expandMediaAssets(ctx context.Context, tokenDTO *dto.TokenRes
 		if tokenDTO.EnrichmentSource != nil {
 			sourceURLs = append(sourceURLs, tokenDTO.EnrichmentSource.MediaURLs()...)
 		}
+	}
+
+	// Add health-filtered display URLs to the DB lookup so that media assets are always
+	// fetchable for any URL that ApplyHealthyMediaURLs selected from token_media_health.media_url.
+	// ApplyHealthyMediaURLs reads the URL directly from the health row, which can differ from the
+	// raw metadata/enrichment URL during the narrow window between a propagation transaction commit
+	// and the metadata bulk read. Without this, media assets for health-row URLs that are absent
+	// from metadata/enrichment are never queried, so collectMediaAssetDTOsFromMap returns nothing
+	// for them — contradicting the OpenAPI contract that display+media_asset surfaces assets for
+	// the health-filtered display URLs.
+	// populateHealthFilteredDisplay must be called before expandMediaAssets for this to be effective.
+	if expansionMap[types.ExpansionDisplay] && tokenDTO.Display != nil {
+		sourceURLs = append(sourceURLs, tokenDTO.Display.MediaURLs()...)
 	}
 
 	if len(sourceURLs) == 0 {

--- a/internal/api/shared/executor/executor.go
+++ b/internal/api/shared/executor/executor.go
@@ -150,6 +150,24 @@ func (e *executor) GetToken(ctx context.Context, tokenCID string, expansions []t
 				}
 			}
 		case types.ExpansionMediaAsset:
+			// When display is also requested, pre-populate the health-filtered display before
+			// expandMediaAssets runs. expandMediaAssets is called inside this loop while
+			// tokenDTO.Display is only set in the post-loop block; without pre-population,
+			// display-derived media assets would be silently omitted.
+			// Ensure metadata and enrichment are available first (display needs both).
+			if containsExpansion(expansions, types.ExpansionDisplay) {
+				if tokenDTO.Metadata == nil {
+					if err := e.expandMetadata(ctx, tokenDTO, token.ID); err != nil {
+						return nil, err
+					}
+				}
+				if tokenDTO.EnrichmentSource == nil {
+					if err := e.expandEnrichmentSource(ctx, tokenDTO, token.ID); err != nil {
+						return nil, err
+					}
+				}
+				e.populateHealthFilteredDisplay(ctx, tokenDTO, token.ID)
+			}
 			if err := e.expandMediaAssets(ctx, tokenDTO, expansions); err != nil {
 				return nil, err
 			}
@@ -158,21 +176,11 @@ func (e *executor) GetToken(ctx context.Context, tokenCID string, expansions []t
 		expansionMap[exp] = true
 	}
 
-	// Populate display field if requested and clean up internal data if not explicitly requested
+	// Populate display field if requested and clean up internal data if not explicitly requested.
+	// populateHealthFilteredDisplay is idempotent: if media_asset expansion already ran first and
+	// pre-populated the field, this is a no-op — no extra DB round trip.
 	if expansionMap[types.ExpansionDisplay] {
-		// Merge the data into display field
-		tokenDTO.Display = dto.MergeTokenDisplay(tokenDTO.Metadata, tokenDTO.EnrichmentSource)
-
-		// Apply health-aware URL filtering: replace or remove URLs that are not confirmed healthy
-		// in token_media_health so FF1 never receives a dead or unverified gateway URL.
-		// Fetch health rows only when display is requested — avoids an extra query otherwise.
-		// On query error we pass nil rows: ApplyHealthyMediaURLs treats that as "no data yet" and
-		// returns the merged display unchanged (same behavior as the GetTokens bulk path).
-		healthByToken, err := e.store.GetTokenMediaHealthByTokenIDs(ctx, []uint64{token.ID})
-		if err != nil {
-			logger.ErrorCtx(ctx, err, zap.String("token_cid", tokenDTO.TokenCID))
-		}
-		tokenDTO.Display = dto.ApplyHealthyMediaURLs(tokenDTO.Display, healthByToken[token.ID])
+		e.populateHealthFilteredDisplay(ctx, tokenDTO, token.ID)
 
 		// Replace any data URI image/animation URLs with the public variant from media_assets
 		if err := e.resolveDisplayDataURIs(ctx, []dto.TokenResponse{*tokenDTO}); err != nil {
@@ -905,6 +913,37 @@ func mediaAssetLookupKey(url string) string {
 		return ""
 	}
 	return internalTypes.MD5Hash(url)
+}
+
+// populateHealthFilteredDisplay merges metadata and enrichment source into tokenDTO.Display and
+// applies health filtering against token_media_health so only confirmed-healthy URLs are served.
+//
+// It is idempotent: if tokenDTO.Display is already set the call is a no-op, which allows callers
+// to call it from multiple code paths without incurring a second DB round trip.
+//
+// On a health-query error the function logs and proceeds — ApplyHealthyMediaURLs with nil rows
+// returns the merged display unchanged (passthrough). This preserves availability when the
+// token_media_health table is temporarily unavailable and is an intentional trade-off.
+func (e *executor) populateHealthFilteredDisplay(ctx context.Context, tokenDTO *dto.TokenResponse, tokenID uint64) {
+	if tokenDTO.Display != nil {
+		return
+	}
+	tokenDTO.Display = dto.MergeTokenDisplay(tokenDTO.Metadata, tokenDTO.EnrichmentSource)
+	healthByToken, err := e.store.GetTokenMediaHealthByTokenIDs(ctx, []uint64{tokenID})
+	if err != nil {
+		logger.ErrorCtx(ctx, err, zap.String("token_cid", tokenDTO.TokenCID))
+	}
+	tokenDTO.Display = dto.ApplyHealthyMediaURLs(tokenDTO.Display, healthByToken[tokenID])
+}
+
+// containsExpansion reports whether exp appears in the expansions slice.
+func containsExpansion(expansions []types.Expansion, exp types.Expansion) bool {
+	for _, e := range expansions {
+		if e == exp {
+			return true
+		}
+	}
+	return false
 }
 
 // expandMediaAssets expands both metadata and enrichment source media assets (unified approach)

--- a/internal/api/shared/executor/executor.go
+++ b/internal/api/shared/executor/executor.go
@@ -163,16 +163,16 @@ func (e *executor) GetToken(ctx context.Context, tokenCID string, expansions []t
 		// Merge the data into display field
 		tokenDTO.Display = dto.MergeTokenDisplay(tokenDTO.Metadata, tokenDTO.EnrichmentSource)
 
-		// Apply health-aware URL filtering: replace or remove URLs that are broken according to
-		// token_media_health so FF1 never receives a dead gateway URL from display.animation_url.
+		// Apply health-aware URL filtering: replace or remove URLs that are not confirmed healthy
+		// in token_media_health so FF1 never receives a dead or unverified gateway URL.
 		// Fetch health rows only when display is requested — avoids an extra query otherwise.
+		// On query error we pass nil rows: ApplyHealthyMediaURLs treats that as "no data yet" and
+		// returns the merged display unchanged (same behavior as the GetTokens bulk path).
 		healthByToken, err := e.store.GetTokenMediaHealthByTokenIDs(ctx, []uint64{token.ID})
 		if err != nil {
-			// Non-fatal: log and continue with the merged (unfiltered) display.
 			logger.ErrorCtx(ctx, err, zap.String("token_cid", tokenDTO.TokenCID))
-		} else {
-			tokenDTO.Display = dto.ApplyHealthyMediaURLs(tokenDTO.Display, healthByToken[token.ID])
 		}
+		tokenDTO.Display = dto.ApplyHealthyMediaURLs(tokenDTO.Display, healthByToken[token.ID])
 
 		// Replace any data URI image/animation URLs with the public variant from media_assets
 		if err := e.resolveDisplayDataURIs(ctx, []dto.TokenResponse{*tokenDTO}); err != nil {
@@ -1016,10 +1016,11 @@ func (e *executor) expandMediaAssets(ctx context.Context, tokenDTO *dto.TokenRes
 	}
 
 	// Collect media URLs from display if both display and media_asset are requested.
+	// Use tokenDTO.Display (already health-filtered) rather than re-running MergeTokenDisplay,
+	// so media assets are consistent with what is actually surfaced in the display field.
 	if expansionMap[types.ExpansionDisplay] && expansionMap[types.ExpansionMediaAsset] {
-		localDisplay := dto.MergeTokenDisplay(tokenDTO.Metadata, tokenDTO.EnrichmentSource)
-		if localDisplay != nil {
-			for _, url := range localDisplay.MediaURLs() {
+		if tokenDTO.Display != nil {
+			for _, url := range tokenDTO.Display.MediaURLs() {
 				mediaURLsMap[url] = true
 			}
 		}

--- a/internal/api/shared/executor/executor.go
+++ b/internal/api/shared/executor/executor.go
@@ -166,7 +166,9 @@ func (e *executor) GetToken(ctx context.Context, tokenCID string, expansions []t
 						return nil, err
 					}
 				}
-				e.populateHealthFilteredDisplay(ctx, tokenDTO, token.ID)
+				if err := e.populateHealthFilteredDisplay(ctx, tokenDTO, token.ID); err != nil {
+					return nil, err
+				}
 			}
 			if err := e.expandMediaAssets(ctx, tokenDTO, expansions); err != nil {
 				return nil, err
@@ -180,7 +182,9 @@ func (e *executor) GetToken(ctx context.Context, tokenCID string, expansions []t
 	// populateHealthFilteredDisplay is idempotent: if media_asset expansion already ran first and
 	// pre-populated the field, this is a no-op — no extra DB round trip.
 	if expansionMap[types.ExpansionDisplay] {
-		e.populateHealthFilteredDisplay(ctx, tokenDTO, token.ID)
+		if err := e.populateHealthFilteredDisplay(ctx, tokenDTO, token.ID); err != nil {
+			return nil, err
+		}
 
 		// Replace any data URI image/animation URLs with the public variant from media_assets
 		if err := e.resolveDisplayDataURIs(ctx, []dto.TokenResponse{*tokenDTO}); err != nil {
@@ -354,9 +358,7 @@ func (e *executor) GetTokens(ctx context.Context, owners []string, chains []doma
 				// Bulk-fetch health rows in one query to avoid N+1 when iterating tokens.
 				bulkMediaHealth, err = e.store.GetTokenMediaHealthByTokenIDs(ctx, tokenIDsForBulk)
 				if err != nil {
-					// Non-fatal: log and proceed without health filtering.
-					logger.ErrorCtx(ctx, err)
-					bulkMediaHealth = map[uint64][]schema.TokenMediaHealth{}
+					return nil, apierrors.NewDatabaseError(fmt.Sprintf("Failed to get token media health: %v", err))
 				}
 			}
 		}
@@ -940,19 +942,20 @@ func mediaAssetLookupKey(url string) string {
 // It is idempotent: if tokenDTO.Display is already set the call is a no-op, which allows callers
 // to call it from multiple code paths without incurring a second DB round trip.
 //
-// On a health-query error the function logs and proceeds — ApplyHealthyMediaURLs with nil rows
-// returns the merged display unchanged (passthrough). This preserves availability when the
-// token_media_health table is temporarily unavailable and is an intentional trade-off.
-func (e *executor) populateHealthFilteredDisplay(ctx context.Context, tokenDTO *dto.TokenResponse, tokenID uint64) {
+// Health state is a correctness dependency of display: a failure here should propagate like any
+// other expansion DB failure (metadata, enrichment) rather than silently fall back to serving
+// stale or broken URLs. Callers must check the returned error.
+func (e *executor) populateHealthFilteredDisplay(ctx context.Context, tokenDTO *dto.TokenResponse, tokenID uint64) error {
 	if tokenDTO.Display != nil {
-		return
+		return nil
 	}
 	tokenDTO.Display = dto.MergeTokenDisplay(tokenDTO.Metadata, tokenDTO.EnrichmentSource)
 	healthByToken, err := e.store.GetTokenMediaHealthByTokenIDs(ctx, []uint64{tokenID})
 	if err != nil {
-		logger.ErrorCtx(ctx, err, zap.String("token_cid", tokenDTO.TokenCID))
+		return apierrors.NewDatabaseError(fmt.Sprintf("Failed to get token media health: %v", err))
 	}
 	tokenDTO.Display = dto.ApplyHealthyMediaURLs(tokenDTO.Display, healthByToken[tokenID])
+	return nil
 }
 
 // containsExpansion reports whether exp appears in the expansions slice.

--- a/internal/api/shared/executor/executor.go
+++ b/internal/api/shared/executor/executor.go
@@ -163,6 +163,17 @@ func (e *executor) GetToken(ctx context.Context, tokenCID string, expansions []t
 		// Merge the data into display field
 		tokenDTO.Display = dto.MergeTokenDisplay(tokenDTO.Metadata, tokenDTO.EnrichmentSource)
 
+		// Apply health-aware URL filtering: replace or remove URLs that are broken according to
+		// token_media_health so FF1 never receives a dead gateway URL from display.animation_url.
+		// Fetch health rows only when display is requested — avoids an extra query otherwise.
+		healthByToken, err := e.store.GetTokenMediaHealthByTokenIDs(ctx, []uint64{token.ID})
+		if err != nil {
+			// Non-fatal: log and continue with the merged (unfiltered) display.
+			logger.ErrorCtx(ctx, err, zap.String("token_cid", tokenDTO.TokenCID))
+		} else {
+			tokenDTO.Display = dto.ApplyHealthyMediaURLs(tokenDTO.Display, healthByToken[token.ID])
+		}
+
 		// Replace any data URI image/animation URLs with the public variant from media_assets
 		if err := e.resolveDisplayDataURIs(ctx, []dto.TokenResponse{*tokenDTO}); err != nil {
 			return nil, err
@@ -270,6 +281,7 @@ func (e *executor) GetTokens(ctx context.Context, owners []string, chains []doma
 	var bulkOwnerProvenancesTotals map[uint64]uint64
 	var bulkEnrichmentSources map[uint64]*schema.EnrichmentSource
 	var bulkMetadata map[uint64]*schema.TokenMetadata
+	var bulkMediaHealth map[uint64][]schema.TokenMediaHealth
 	var allMediaSourceURLs []string
 
 	// Map to track which expansions were requested
@@ -316,8 +328,8 @@ func (e *executor) GetTokens(ctx context.Context, owners []string, chains []doma
 				}
 			}
 		case types.ExpansionDisplay:
-			// Display expansion requires metadata and enrichment_source internally
-			// Fetch them if not already fetched
+			// Display expansion requires metadata, enrichment_source, and media health internally.
+			// Fetch them all if not already fetched.
 			if bulkMetadata == nil {
 				bulkMetadata, err = e.store.GetTokenMetadataByTokenIDs(ctx, tokenIDsForBulk)
 				if err != nil {
@@ -328,6 +340,15 @@ func (e *executor) GetTokens(ctx context.Context, owners []string, chains []doma
 				bulkEnrichmentSources, err = e.store.GetEnrichmentSourcesByTokenIDs(ctx, tokenIDsForBulk)
 				if err != nil {
 					return nil, apierrors.NewDatabaseError(fmt.Sprintf("Failed to get enrichment sources: %v", err))
+				}
+			}
+			if bulkMediaHealth == nil {
+				// Bulk-fetch health rows in one query to avoid N+1 when iterating tokens.
+				bulkMediaHealth, err = e.store.GetTokenMediaHealthByTokenIDs(ctx, tokenIDsForBulk)
+				if err != nil {
+					// Non-fatal: log and proceed without health filtering.
+					logger.ErrorCtx(ctx, err)
+					bulkMediaHealth = map[uint64][]schema.TokenMediaHealth{}
 				}
 			}
 		}
@@ -455,8 +476,10 @@ func (e *executor) GetTokens(ctx context.Context, owners []string, chains []doma
 			metadataForDisplay := dto.MapTokenMetadataToDTO(metadata)
 			enrichmentForDisplay := dto.MapEnrichmentSourceToDTO(enrichment)
 
-			// Merge into display field
+			// Merge into display field, then apply health-aware URL filtering so broken
+			// gateway URLs are never served to FF1 clients.
 			tokenDTO.Display = dto.MergeTokenDisplay(metadataForDisplay, enrichmentForDisplay)
+			tokenDTO.Display = dto.ApplyHealthyMediaURLs(tokenDTO.Display, bulkMediaHealth[token.ID])
 
 			// Collect media URLs from display field if media_asset was requested
 			if expansionMap[types.ExpansionMediaAsset] && tokenDTO.Display != nil {

--- a/internal/api/shared/executor/executor_test.go
+++ b/internal/api/shared/executor/executor_test.go
@@ -137,6 +137,180 @@ func (f *displayMediaAssetFixture) setupMocks(mockStore *mocks.MockStore) {
 		Return([]schema.MediaAsset{f.mediaAsset}, nil)
 }
 
+// containsURL returns a Matcher that verifies a []string argument contains target.
+// Used to assert GetMediaAssetsBySourceURLs is called with a URL that may only exist in
+// token_media_health.media_url (not in raw metadata/enrichment), which is the scenario our
+// fix must handle.
+func containsURL(target string) gomock.Matcher {
+	return gomock.Cond(func(x any) bool {
+		urls, ok := x.([]string)
+		if !ok {
+			return false
+		}
+		for _, u := range urls {
+			if u == target {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// healthOnlyFixture represents the scenario where ApplyHealthyMediaURLs selects a URL that
+// exists only in token_media_health.media_url and NOT in raw metadata or enrichment sources.
+//
+// This simulates the PostgreSQL READ COMMITTED race window: the API reads metadata before a
+// propagation transaction commits (metadata still has originalURL) but reads the health table
+// after it commits (health row already has workingURL). ApplyHealthyMediaURLs then sets
+// display.animation_url = workingURL, which would be absent from the media asset source URL
+// set built from raw metadata — causing collectMediaAssetDTOsFromMap to return nothing for it
+// without the fix that adds tokenDTO.Display.MediaURLs() to the DB lookup.
+type healthOnlyFixture struct {
+	tokenID       uint64
+	normalizedCID string
+	originalURL   string // stale/broken URL still in metadata
+	workingURL    string // healthy URL only in health table
+	token         *schema.Token
+	metadata      *schema.TokenMetadata
+	healthRows    map[uint64][]schema.TokenMediaHealth
+	mediaAsset    schema.MediaAsset
+}
+
+func newHealthOnlyFixture() *healthOnlyFixture {
+	const tokenID = uint64(43)
+	const rawCID = "eip155:1:erc721:0xdef456:2" //nolint:gosec
+	normalizedCID := domain.TokenCID(rawCID).Normalized().String()
+	originalURL := "https://ipfs.feralfile.com/ipfs/QmSTALE"
+	workingURL := "https://ipfs.io/ipfs/QmWORKING"
+
+	return &healthOnlyFixture{
+		tokenID:       tokenID,
+		normalizedCID: normalizedCID,
+		originalURL:   originalURL,
+		workingURL:    workingURL,
+		token: &schema.Token{
+			ID:         tokenID,
+			TokenCID:   normalizedCID,
+			Chain:      "eip155:1",
+			Standard:   "erc721",
+			IsViewable: true,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+		metadata: &schema.TokenMetadata{
+			TokenID:      tokenID,
+			AnimationURL: ptrStr(originalURL), // stale; health row has workingURL
+		},
+		healthRows: map[uint64][]schema.TokenMediaHealth{
+			tokenID: {
+				{
+					TokenID:      tokenID,
+					MediaURL:     workingURL,
+					MediaSource:  schema.MediaHealthSourceMetadataAnimation,
+					HealthStatus: schema.MediaHealthStatusHealthy,
+				},
+			},
+		},
+		mediaAsset: schema.MediaAsset{
+			ID:            2,
+			SourceURL:     workingURL,
+			SourceURLHash: internalTypes.MD5Hash(workingURL),
+			Provider:      "cloudflare",
+		},
+	}
+}
+
+// TestGetToken_DisplayAndMediaAsset_HealthOnlyURL verifies the fix for the media asset
+// lookup miss when the display URL comes only from token_media_health (not from raw
+// metadata/enrichment). The fix appends tokenDTO.Display.MediaURLs() to the source URL
+// set in expandMediaAssets before the DB fetch, ensuring the media asset is found.
+func TestGetToken_DisplayAndMediaAsset_HealthOnlyURL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := newHealthOnlyFixture()
+	exec, mockStore := newTestExecutor(t, ctrl)
+
+	mockStore.EXPECT().
+		GetTokenByTokenCID(gomock.Any(), f.normalizedCID).
+		Return(f.token, nil)
+	mockStore.EXPECT().
+		GetTokenMetadataByTokenID(gomock.Any(), f.tokenID).
+		Return(f.metadata, nil).
+		AnyTimes()
+	mockStore.EXPECT().
+		GetEnrichmentSourceByTokenID(gomock.Any(), f.tokenID).
+		Return(nil, nil).
+		AnyTimes()
+	mockStore.EXPECT().
+		GetTokenMediaHealthByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(f.healthRows, nil)
+	// workingURL exists only in the health table, not in raw metadata. The fix must add it
+	// to the DB lookup. If it does not, this expectation will fail (missing call).
+	mockStore.EXPECT().
+		GetMediaAssetsBySourceURLs(gomock.Any(), containsURL(f.workingURL)).
+		Return([]schema.MediaAsset{f.mediaAsset}, nil)
+
+	const rawCID = "eip155:1:erc721:0xdef456:2" //nolint:gosec
+	result, err := exec.GetToken(context.Background(), rawCID,
+		[]types.Expansion{types.ExpansionDisplay, types.ExpansionMediaAsset},
+		nil, nil, nil, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Display, "display must be populated")
+	assert.Equal(t, f.workingURL, *result.Display.AnimationURL,
+		"display.animation_url must be the URL from the health table, not the stale metadata URL")
+	require.NotNil(t, result.MediaAssets, "media_assets must be populated")
+	assert.Len(t, result.MediaAssets, 1, "exactly one media asset expected for the working URL")
+	assert.Equal(t, f.workingURL, result.MediaAssets[0].SourceURL,
+		"media asset source URL must match the health-filtered display URL")
+}
+
+// TestGetTokens_DisplayAndMediaAsset_HealthOnlyURL verifies the list-path analog: the bulk
+// pre-compute loop in GetTokens adds health-filtered display URLs to allMediaSourceURLs before
+// GetMediaAssetsBySourceURLs is called, so the media asset map contains the workingURL entry.
+func TestGetTokens_DisplayAndMediaAsset_HealthOnlyURL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := newHealthOnlyFixture()
+	exec, mockStore := newTestExecutor(t, ctrl)
+
+	mockStore.EXPECT().
+		GetTokensByFilter(gomock.Any(), gomock.Any()).
+		Return([]schema.Token{*f.token}, nil)
+	mockStore.EXPECT().
+		GetTokenMetadataByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(map[uint64]*schema.TokenMetadata{f.tokenID: f.metadata}, nil)
+	mockStore.EXPECT().
+		GetEnrichmentSourcesByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(map[uint64]*schema.EnrichmentSource{}, nil)
+	mockStore.EXPECT().
+		GetTokenMediaHealthByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(f.healthRows, nil)
+	// The pre-compute loop must have added workingURL to allMediaSourceURLs.
+	mockStore.EXPECT().
+		GetMediaAssetsBySourceURLs(gomock.Any(), containsURL(f.workingURL)).
+		Return([]schema.MediaAsset{f.mediaAsset}, nil)
+
+	result, err := exec.GetTokens(context.Background(),
+		nil, nil, nil, nil, []uint64{f.tokenID}, nil,
+		nil, nil, nil, nil, nil,
+		[]types.Expansion{types.ExpansionDisplay, types.ExpansionMediaAsset})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Tokens, 1)
+	tok := result.Tokens[0]
+	require.NotNil(t, tok.Display, "display must be populated")
+	assert.Equal(t, f.workingURL, *tok.Display.AnimationURL,
+		"display.animation_url must be the health-table URL (workingURL)")
+	require.NotNil(t, tok.MediaAssets, "media_assets must be populated")
+	assert.Len(t, tok.MediaAssets, 1)
+	assert.Equal(t, f.workingURL, tok.MediaAssets[0].SourceURL)
+}
+
 // TestGetToken_DisplayAndMediaAsset_HealthFiltered verifies the fix for the regression where
 // display+media_asset expansion could return zero display-derived media assets because
 // expandMediaAssets ran before tokenDTO.Display was populated.

--- a/internal/api/shared/executor/executor_test.go
+++ b/internal/api/shared/executor/executor_test.go
@@ -1,0 +1,198 @@
+package executor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/feral-file/ff-indexer-v2/internal/adapter"
+	"github.com/feral-file/ff-indexer-v2/internal/api/shared/executor"
+	"github.com/feral-file/ff-indexer-v2/internal/api/shared/types"
+	"github.com/feral-file/ff-indexer-v2/internal/domain"
+	"github.com/feral-file/ff-indexer-v2/internal/mocks"
+	"github.com/feral-file/ff-indexer-v2/internal/store/schema"
+	internalTypes "github.com/feral-file/ff-indexer-v2/internal/types"
+)
+
+// newTestExecutor builds an executor wired with a mock store and real JSON/clock adapters.
+// Only the store mock is returned because all other dependencies are not exercised by display tests.
+func newTestExecutor(t *testing.T, ctrl *gomock.Controller) (executor.Executor, *mocks.MockStore) {
+	t.Helper()
+	mockStore := mocks.NewMockStore(ctrl)
+	mockJobQueue := mocks.NewMockJobQueue(ctrl)
+	mockBlacklist := mocks.NewMockBlacklistRegistry(ctrl)
+	exec := executor.NewExecutor(
+		mockStore,
+		mockJobQueue,
+		"token_index",
+		mockBlacklist,
+		adapter.NewJSON(),
+		adapter.NewClock(),
+		domain.Chain("tezos:mainnet"),
+		domain.Chain("eip155:1"),
+	)
+	return exec, mockStore
+}
+
+// ptrStr is a convenience helper that returns a *string.
+func ptrStr(s string) *string { return &s }
+
+// displayMediaAssetFixture holds the shared state for display+media_asset expansion tests.
+type displayMediaAssetFixture struct {
+	tokenID       uint64
+	rawCID        string
+	normalizedCID string
+	brokenURL     string
+	healthyURL    string
+	token         *schema.Token
+	metadata      *schema.TokenMetadata
+	enrichment    *schema.EnrichmentSource
+	healthRows    map[uint64][]schema.TokenMediaHealth
+	mediaAsset    schema.MediaAsset
+}
+
+// newDisplayMediaAssetFixture constructs the test state shared across display+media_asset tests.
+// Scenario: enrichment has a broken animation URL; metadata has a healthy one.
+// After health filtering, display and media_assets must both use the healthy metadata URL.
+func newDisplayMediaAssetFixture() *displayMediaAssetFixture {
+	const tokenID = uint64(42)
+	const rawCID = "eip155:1:erc721:0xabc123:1" //nolint:gosec
+	// The executor normalizes token CIDs before the store lookup; precompute for mock expectations.
+	normalizedCID := domain.TokenCID(rawCID).Normalized().String()
+	brokenURL := "https://ipfs.feralfile.com/ipfs/QmBROKEN"
+	healthyURL := "https://ipfs.io/ipfs/QmHEALTHY"
+
+	return &displayMediaAssetFixture{
+		tokenID:       tokenID,
+		rawCID:        rawCID,
+		normalizedCID: normalizedCID,
+		brokenURL:     brokenURL,
+		healthyURL:    healthyURL,
+		token: &schema.Token{
+			ID:         tokenID,
+			TokenCID:   normalizedCID,
+			Chain:      "eip155:1",
+			Standard:   "erc721",
+			IsViewable: true,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+		metadata: &schema.TokenMetadata{
+			TokenID:      tokenID,
+			AnimationURL: ptrStr(healthyURL),
+		},
+		enrichment: &schema.EnrichmentSource{
+			TokenID:      tokenID,
+			Vendor:       "feralfile",
+			AnimationURL: ptrStr(brokenURL), // higher merge precedence but broken
+		},
+		healthRows: map[uint64][]schema.TokenMediaHealth{
+			tokenID: {
+				{
+					TokenID:      tokenID,
+					MediaURL:     brokenURL,
+					MediaSource:  schema.MediaHealthSourceEnrichmentAnimation,
+					HealthStatus: schema.MediaHealthStatusBroken,
+				},
+				{
+					TokenID:      tokenID,
+					MediaURL:     healthyURL,
+					MediaSource:  schema.MediaHealthSourceMetadataAnimation,
+					HealthStatus: schema.MediaHealthStatusHealthy,
+				},
+			},
+		},
+		mediaAsset: schema.MediaAsset{
+			ID:            1,
+			SourceURL:     healthyURL,
+			SourceURLHash: internalTypes.MD5Hash(healthyURL),
+			Provider:      "cloudflare",
+		},
+	}
+}
+
+func (f *displayMediaAssetFixture) setupMocks(mockStore *mocks.MockStore) {
+	mockStore.EXPECT().
+		GetTokenByTokenCID(gomock.Any(), f.normalizedCID).
+		Return(f.token, nil)
+	// Metadata and enrichment may be fetched more than once depending on expansion order
+	// (display pre-population in the media_asset case + the media_asset source collection).
+	mockStore.EXPECT().
+		GetTokenMetadataByTokenID(gomock.Any(), f.tokenID).
+		Return(f.metadata, nil).
+		AnyTimes()
+	mockStore.EXPECT().
+		GetEnrichmentSourceByTokenID(gomock.Any(), f.tokenID).
+		Return(f.enrichment, nil).
+		AnyTimes()
+	mockStore.EXPECT().
+		GetTokenMediaHealthByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(f.healthRows, nil)
+	mockStore.EXPECT().
+		GetMediaAssetsBySourceURLs(gomock.Any(), gomock.Any()).
+		Return([]schema.MediaAsset{f.mediaAsset}, nil)
+}
+
+// TestGetToken_DisplayAndMediaAsset_HealthFiltered verifies the fix for the regression where
+// display+media_asset expansion could return zero display-derived media assets because
+// expandMediaAssets ran before tokenDTO.Display was populated.
+//
+// Scenario: enrichment animation URL is broken; metadata animation URL is healthy.
+// Expected: display.animation_url = healthy metadata URL; media_assets derived from healthy URL only.
+func TestGetToken_DisplayAndMediaAsset_HealthFiltered(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := newDisplayMediaAssetFixture()
+	exec, mockStore := newTestExecutor(t, ctrl)
+	f.setupMocks(mockStore)
+
+	expansions := []types.Expansion{types.ExpansionDisplay, types.ExpansionMediaAsset}
+	result, err := exec.GetToken(context.Background(), f.rawCID, expansions, nil, nil, nil, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// display.animation_url must be the healthy metadata URL, not the broken enrichment URL
+	require.NotNil(t, result.Display, "display should be populated")
+	assert.Equal(t, f.healthyURL, *result.Display.AnimationURL,
+		"display.animation_url must be the confirmed-healthy URL, not the broken enrichment URL")
+
+	// media_assets must be derived from the health-filtered display URL
+	require.NotNil(t, result.MediaAssets, "media_assets should be populated")
+	assert.Len(t, result.MediaAssets, 1, "only the healthy URL should produce a media asset")
+	assert.Equal(t, f.healthyURL, result.MediaAssets[0].SourceURL,
+		"media asset source URL must match the health-filtered display URL")
+}
+
+// TestGetToken_DisplayAndMediaAsset_ReverseExpansionOrder verifies that the ordering of
+// expand=media_asset before expand=display produces the same health-filtered result.
+// This was the key regression: media_asset expansion ran inside the loop while display
+// was only populated in the post-loop block, so reversing the order left tokenDTO.Display
+// nil when expandMediaAssets tried to read it.
+func TestGetToken_DisplayAndMediaAsset_ReverseExpansionOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := newDisplayMediaAssetFixture()
+	exec, mockStore := newTestExecutor(t, ctrl)
+	f.setupMocks(mockStore)
+
+	// Reverse order: media_asset before display — this was the broken case before the fix.
+	expansions := []types.Expansion{types.ExpansionMediaAsset, types.ExpansionDisplay}
+	result, err := exec.GetToken(context.Background(), f.rawCID, expansions, nil, nil, nil, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Display, "display should be populated regardless of expansion order")
+	assert.Equal(t, f.healthyURL, *result.Display.AnimationURL,
+		"display.animation_url must be the healthy URL regardless of expansion order")
+	require.NotNil(t, result.MediaAssets, "media_assets should be populated regardless of expansion order")
+	assert.Len(t, result.MediaAssets, 1)
+	assert.Equal(t, f.healthyURL, result.MediaAssets[0].SourceURL,
+		"media asset source URL must match the health-filtered display URL")
+}

--- a/internal/api/shared/executor/executor_test.go
+++ b/internal/api/shared/executor/executor_test.go
@@ -2,6 +2,7 @@ package executor_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -369,4 +370,69 @@ func TestGetToken_DisplayAndMediaAsset_ReverseExpansionOrder(t *testing.T) {
 	assert.Len(t, result.MediaAssets, 1)
 	assert.Equal(t, f.healthyURL, result.MediaAssets[0].SourceURL,
 		"media asset source URL must match the health-filtered display URL")
+}
+
+// TestGetToken_DisplayExpansion_HealthQueryFailure verifies that a GetTokenMediaHealthByTokenIDs
+// failure causes GetToken to return an error rather than silently passing through stale or
+// broken display URLs. Health state is a correctness dependency of the display expansion, so
+// its failure must be handled like metadata/enrichment DB failures.
+func TestGetToken_DisplayExpansion_HealthQueryFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := newDisplayMediaAssetFixture()
+	exec, mockStore := newTestExecutor(t, ctrl)
+
+	mockStore.EXPECT().
+		GetTokenByTokenCID(gomock.Any(), f.normalizedCID).
+		Return(f.token, nil)
+	mockStore.EXPECT().
+		GetTokenMetadataByTokenID(gomock.Any(), f.tokenID).
+		Return(f.metadata, nil).
+		AnyTimes()
+	mockStore.EXPECT().
+		GetEnrichmentSourceByTokenID(gomock.Any(), f.tokenID).
+		Return(f.enrichment, nil).
+		AnyTimes()
+	mockStore.EXPECT().
+		GetTokenMediaHealthByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(nil, errors.New("connection timeout"))
+
+	result, err := exec.GetToken(context.Background(), f.rawCID,
+		[]types.Expansion{types.ExpansionDisplay}, nil, nil, nil, nil, nil)
+
+	require.Error(t, err, "GetToken must propagate health query failure as an error")
+	assert.Nil(t, result, "result must be nil on health query failure")
+}
+
+// TestGetTokens_DisplayExpansion_HealthQueryFailure verifies that a GetTokenMediaHealthByTokenIDs
+// failure causes GetTokens to return an error. The list path must behave consistently with the
+// single-token path and with other expansion DB failures (metadata, enrichment).
+func TestGetTokens_DisplayExpansion_HealthQueryFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := newHealthOnlyFixture()
+	exec, mockStore := newTestExecutor(t, ctrl)
+
+	mockStore.EXPECT().
+		GetTokensByFilter(gomock.Any(), gomock.Any()).
+		Return([]schema.Token{*f.token}, nil)
+	mockStore.EXPECT().
+		GetTokenMetadataByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(map[uint64]*schema.TokenMetadata{f.tokenID: f.metadata}, nil)
+	mockStore.EXPECT().
+		GetEnrichmentSourcesByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(map[uint64]*schema.EnrichmentSource{}, nil)
+	mockStore.EXPECT().
+		GetTokenMediaHealthByTokenIDs(gomock.Any(), []uint64{f.tokenID}).
+		Return(nil, errors.New("connection timeout"))
+
+	result, err := exec.GetTokens(context.Background(),
+		nil, nil, nil, nil, []uint64{f.tokenID}, nil,
+		nil, nil, nil, nil, nil,
+		[]types.Expansion{types.ExpansionDisplay})
+
+	require.Error(t, err, "GetTokens must propagate health query failure as an error")
+	assert.Nil(t, result, "result must be nil on health query failure")
 }

--- a/internal/mocks/store.go
+++ b/internal/mocks/store.go
@@ -567,6 +567,21 @@ func (mr *MockStoreMockRecorder) GetTokenIDsByMediaURL(ctx, url any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTokenIDsByMediaURL", reflect.TypeOf((*MockStore)(nil).GetTokenIDsByMediaURL), ctx, url)
 }
 
+// GetTokenMediaHealthByTokenIDs mocks base method.
+func (m *MockStore) GetTokenMediaHealthByTokenIDs(ctx context.Context, tokenIDs []uint64) (map[uint64][]schema.TokenMediaHealth, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTokenMediaHealthByTokenIDs", ctx, tokenIDs)
+	ret0, _ := ret[0].(map[uint64][]schema.TokenMediaHealth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTokenMediaHealthByTokenIDs indicates an expected call of GetTokenMediaHealthByTokenIDs.
+func (mr *MockStoreMockRecorder) GetTokenMediaHealthByTokenIDs(ctx, tokenIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTokenMediaHealthByTokenIDs", reflect.TypeOf((*MockStore)(nil).GetTokenMediaHealthByTokenIDs), ctx, tokenIDs)
+}
+
 // GetTokenMetadataByTokenCID mocks base method.
 func (m *MockStore) GetTokenMetadataByTokenCID(ctx context.Context, tokenCID string) (*schema.TokenMetadata, error) {
 	m.ctrl.T.Helper()

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -2646,6 +2646,29 @@ func (s *pgStore) GetTokensViewabilityByIDs(ctx context.Context, tokenIDs []uint
 	return tokens, nil
 }
 
+// GetTokenMediaHealthByTokenIDs returns all health rows for the given token IDs, keyed by token ID.
+// Used by the API display layer to apply health-aware URL selection so broken gateway URLs are
+// never served to clients (see ApplyHealthyMediaURLs in the dto package).
+// Returns an empty map when tokenIDs is empty.
+func (s *pgStore) GetTokenMediaHealthByTokenIDs(ctx context.Context, tokenIDs []uint64) (map[uint64][]schema.TokenMediaHealth, error) {
+	if len(tokenIDs) == 0 {
+		return map[uint64][]schema.TokenMediaHealth{}, nil
+	}
+
+	var rows []schema.TokenMediaHealth
+	if err := s.db.WithContext(ctx).
+		Where("token_id IN ?", tokenIDs).
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to get token media health by token IDs: %w", err)
+	}
+
+	result := make(map[uint64][]schema.TokenMediaHealth, len(tokenIDs))
+	for _, row := range rows {
+		result[row.TokenID] = append(result[row.TokenID], row)
+	}
+	return result, nil
+}
+
 // UpdateTokenMediaHealthByURL updates health status for all records with a specific URL
 func (s *pgStore) UpdateTokenMediaHealthByURL(ctx context.Context, url string, status schema.MediaHealthStatus, lastError *string) error {
 	urlHash := types.MD5Hash(url)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -326,6 +326,9 @@ type Store interface {
 	GetTokenIDsByMediaURL(ctx context.Context, url string) ([]uint64, error)
 	// GetTokensViewabilityByIDs returns viewability status for a specific set of token IDs
 	GetTokensViewabilityByIDs(ctx context.Context, tokenIDs []uint64) ([]TokenViewabilityInfo, error)
+	// GetTokenMediaHealthByTokenIDs returns all health rows keyed by token ID.
+	// Used by the API display layer to serve health-aware URLs instead of raw metadata URLs.
+	GetTokenMediaHealthByTokenIDs(ctx context.Context, tokenIDs []uint64) (map[uint64][]schema.TokenMediaHealth, error)
 	// UpdateTokenMediaHealthByURL updates health status for all records with a specific URL
 	UpdateTokenMediaHealthByURL(ctx context.Context, url string, status schema.MediaHealthStatus, lastError *string) error
 	// UpdateMediaURLAndPropagate updates a URL across token_media_health and source tables (metadata/enrichment) in a transaction

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5984,6 +5984,83 @@ func testMediaHealthOperations(t *testing.T, store Store) {
 		require.NoError(t, err)
 		assert.Empty(t, tokenIDs)
 	})
+
+	t.Run("GetTokenMediaHealthByTokenIDs returns empty map for no IDs", func(t *testing.T) {
+		result, err := store.GetTokenMediaHealthByTokenIDs(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("GetTokenMediaHealthByTokenIDs returns rows keyed by token ID", func(t *testing.T) {
+		animURL := "https://ipfs.feralfile.com/ipfs/QmHealthTestAnim"
+		imgURL := "https://ipfs.filebase.io/ipfs/QmHealthTestImg"
+
+		token := buildTestTokenMint(domain.ChainEthereumMainnet, domain.StandardERC721, "0x0000000000000000000000000000000000300001", "1", "0xownerH")
+		err := store.CreateTokenMint(ctx, token)
+		require.NoError(t, err)
+		tokenData, err := store.GetTokenByTokenCID(ctx, token.Token.TokenCID)
+		require.NoError(t, err)
+
+		metaJSON, _ := json.Marshal(map[string]interface{}{"animation_url": animURL, "image": imgURL})
+		err = store.UpsertTokenMetadata(ctx, CreateTokenMetadataInput{
+			TokenID:         tokenData.ID,
+			OriginJSON:      metaJSON,
+			LatestJSON:      metaJSON,
+			EnrichmentLevel: schema.EnrichmentLevelVendor,
+			AnimationURL:    &animURL,
+			ImageURL:        &imgURL,
+			LastRefreshedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+
+		errMsg := "404 Not Found"
+		err = store.UpdateTokenMediaHealthByURL(ctx, animURL, schema.MediaHealthStatusBroken, &errMsg)
+		require.NoError(t, err)
+		err = store.UpdateTokenMediaHealthByURL(ctx, imgURL, schema.MediaHealthStatusHealthy, nil)
+		require.NoError(t, err)
+
+		result, err := store.GetTokenMediaHealthByTokenIDs(ctx, []uint64{tokenData.ID})
+		require.NoError(t, err)
+
+		rows, ok := result[tokenData.ID]
+		require.True(t, ok, "expected health rows for token")
+		require.Len(t, rows, 2)
+
+		statusByURL := make(map[string]schema.MediaHealthStatus)
+		for _, row := range rows {
+			statusByURL[row.MediaURL] = row.HealthStatus
+		}
+		assert.Equal(t, schema.MediaHealthStatusBroken, statusByURL[animURL])
+		assert.Equal(t, schema.MediaHealthStatusHealthy, statusByURL[imgURL])
+	})
+
+	t.Run("GetTokenMediaHealthByTokenIDs excludes rows for other tokens", func(t *testing.T) {
+		imgURL := "https://ipfs.filebase.io/ipfs/QmHealthTestOtherToken"
+
+		token := buildTestTokenMint(domain.ChainEthereumMainnet, domain.StandardERC721, "0x0000000000000000000000000000000000300002", "2", "0xownerH2")
+		err := store.CreateTokenMint(ctx, token)
+		require.NoError(t, err)
+		tokenData, err := store.GetTokenByTokenCID(ctx, token.Token.TokenCID)
+		require.NoError(t, err)
+
+		metaJSON, _ := json.Marshal(map[string]interface{}{"image": imgURL})
+		err = store.UpsertTokenMetadata(ctx, CreateTokenMetadataInput{
+			TokenID:         tokenData.ID,
+			OriginJSON:      metaJSON,
+			LatestJSON:      metaJSON,
+			EnrichmentLevel: schema.EnrichmentLevelVendor,
+			ImageURL:        &imgURL,
+			LastRefreshedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		err = store.UpdateTokenMediaHealthByURL(ctx, imgURL, schema.MediaHealthStatusHealthy, nil)
+		require.NoError(t, err)
+
+		// Query with a different (non-existent) token ID
+		result, err := store.GetTokenMediaHealthByTokenIDs(ctx, []uint64{tokenData.ID + 99999})
+		require.NoError(t, err)
+		assert.Empty(t, result, "should not return rows for a different token")
+	})
 }
 
 // =============================================================================

--- a/internal/workflows/core_executor.go
+++ b/internal/workflows/core_executor.go
@@ -719,13 +719,21 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 						zap.String("url", result.url),
 						zap.String("working_url", *result.workingURL),
 					)
-					// Non-fatal: fall back to marking the original URL healthy so viewability
-					// is still updated. The sweeper will eventually propagate the correct URL.
-					if err2 := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusHealthy, nil); err2 != nil {
+					// Propagation failed: mark the original URL as broken (it is broken — the
+					// direct probe failed and only the alternate gateway succeeded). Do NOT mark
+					// it healthy and do NOT add the working URL to healthyURLs.
+					// Reason: promoting a known-broken URL to healthy would feed
+					// BatchUpdateTokensViewability with false data, making viewable=true while
+					// the read path still serves the dead gateway URL — reproducing bug #96.
+					// The sweeper will retry UpdateMediaURLAndPropagate and fix the state.
+					if err2 := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusBroken, nil); err2 != nil {
 						logger.ErrorCtx(ctx, err2, zap.String("url", result.url))
 					}
+				} else {
+					// Propagation succeeded: the working URL is now canonical in health table,
+					// metadata, and enrichment_sources. Use it for downstream media indexing.
+					healthyURLs = append(healthyURLs, *result.workingURL)
 				}
-				healthyURLs = append(healthyURLs, *result.workingURL)
 			} else {
 				// Original URL is directly reachable
 				if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusHealthy, nil); err != nil {

--- a/internal/workflows/core_executor.go
+++ b/internal/workflows/core_executor.go
@@ -618,9 +618,10 @@ func (e *coreExecutor) EnhanceTokenMetadata(ctx context.Context, tokenCID domain
 // reachable URLs instead of dead gateway URLs. This mirrors the sweeper's behavior and prevents the
 // false-positive: viewable=true while display.animation_url is a broken gateway URL.
 //
-// Trade-offs: UpdateMediaURLAndPropagate is non-fatal — if propagation fails the original URL is
-// marked healthy as a fallback. The sweeper will eventually re-probe and fix the URL. The healthy
-// URL list always reflects what is actually reachable.
+// Trade-offs: UpdateMediaURLAndPropagate is non-fatal — if propagation fails, the original URL is
+// marked broken (its true health state) and excluded from healthyURLs. The sweeper will eventually
+// retry UpdateMediaURLAndPropagate and fix the state. Marking it healthy would feed
+// BatchUpdateTokensViewability with false data, recreating the viewable=true + broken URL bug (#96).
 func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Context, tokenCID string, mediaURLs []string) (*MediaHealthCheckResult, error) {
 	logger.InfoCtx(ctx, "Checking media health and updating viewability",
 		zap.String("token_cid", tokenCID),

--- a/internal/workflows/core_executor.go
+++ b/internal/workflows/core_executor.go
@@ -609,9 +609,18 @@ func (e *coreExecutor) EnhanceTokenMetadata(ctx context.Context, tokenCID domain
 	return enhanced, nil
 }
 
-// CheckMediaURLsHealthAndUpdateViewability checks media URLs in parallel and updates token viewability
-// This combines URL health checking with viewability computation and DB update
-// Returns a result struct containing viewability status and list of healthy URLs
+// CheckMediaURLsHealthAndUpdateViewability checks media URLs in parallel and updates token viewability.
+// This combines URL health checking with viewability computation and DB update.
+// Returns a result struct containing viewability status and list of healthy URLs.
+//
+// Reason: When the original URL resolves via an alternative gateway (WorkingURL != ""), we propagate
+// the working URL atomically (token_media_health + metadata/enrichment tables) so the API serves
+// reachable URLs instead of dead gateway URLs. This mirrors the sweeper's behavior and prevents the
+// false-positive: viewable=true while display.animation_url is a broken gateway URL.
+//
+// Trade-offs: UpdateMediaURLAndPropagate is non-fatal — if propagation fails the original URL is
+// marked healthy as a fallback. The sweeper will eventually re-probe and fix the URL. The healthy
+// URL list always reflects what is actually reachable.
 func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Context, tokenCID string, mediaURLs []string) (*MediaHealthCheckResult, error) {
 	logger.InfoCtx(ctx, "Checking media health and updating viewability",
 		zap.String("token_cid", tokenCID),
@@ -630,6 +639,7 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 	// Use goroutines to check URLs in parallel
 	type urlResult struct {
 		url          string
+		workingURL   *string // non-nil when an alternative gateway resolved successfully
 		healthStatus schema.MediaHealthStatus
 		lastError    *string
 	}
@@ -644,6 +654,7 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 			defer wg.Done()
 
 			var status schema.MediaHealthStatus
+			var workingURL *string
 			var errMsg *string
 
 			if types.IsDataURI(u) {
@@ -659,6 +670,12 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 				switch result.Status {
 				case uri.HealthStatusHealthy:
 					status = schema.MediaHealthStatusHealthy
+					// Capture the working URL if the checker resolved an alternative gateway.
+					// This happens when the original IPFS/Arweave/OnChFS gateway URL is dead
+					// but the CID is still reachable via another configured gateway.
+					if result.WorkingURL != nil && *result.WorkingURL != u {
+						workingURL = result.WorkingURL
+					}
 				case uri.HealthStatusBroken:
 					status = schema.MediaHealthStatusBroken
 				default:
@@ -669,6 +686,7 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 
 			resultsChan <- urlResult{
 				url:          u,
+				workingURL:   workingURL,
 				healthStatus: status,
 				lastError:    errMsg,
 			}
@@ -686,14 +704,40 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 	for result := range resultsChan {
 		healthStatuses[result.url] = result.healthStatus
 
-		// Collect healthy URLs
 		if result.healthStatus == schema.MediaHealthStatusHealthy {
-			healthyURLs = append(healthyURLs, result.url)
-		}
-
-		// Update media health in database
-		if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, result.healthStatus, result.lastError); err != nil {
-			logger.ErrorCtx(ctx, err, zap.String("url", result.url))
+			if result.workingURL != nil {
+				// Alternative gateway found: propagate the working URL atomically across
+				// token_media_health, token_metadata, and enrichment_sources so the API
+				// immediately serves the reachable URL. This is the same logic as the sweeper.
+				logger.InfoCtx(ctx, "Found working alternative URL during indexing health check",
+					zap.String("token_cid", tokenCID),
+					zap.String("original_url", result.url),
+					zap.String("working_url", *result.workingURL),
+				)
+				if err := e.store.UpdateMediaURLAndPropagate(ctx, result.url, *result.workingURL); err != nil {
+					logger.ErrorCtx(ctx, err,
+						zap.String("url", result.url),
+						zap.String("working_url", *result.workingURL),
+					)
+					// Non-fatal: fall back to marking the original URL healthy so viewability
+					// is still updated. The sweeper will eventually propagate the correct URL.
+					if err2 := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusHealthy, nil); err2 != nil {
+						logger.ErrorCtx(ctx, err2, zap.String("url", result.url))
+					}
+				}
+				healthyURLs = append(healthyURLs, *result.workingURL)
+			} else {
+				// Original URL is directly reachable
+				if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusHealthy, nil); err != nil {
+					logger.ErrorCtx(ctx, err, zap.String("url", result.url))
+				}
+				healthyURLs = append(healthyURLs, result.url)
+			}
+		} else {
+			// Update media health in database for broken/unknown URLs
+			if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, result.healthStatus, result.lastError); err != nil {
+				logger.ErrorCtx(ctx, err, zap.String("url", result.url))
+			}
 		}
 	}
 

--- a/internal/workflows/core_executor_test.go
+++ b/internal/workflows/core_executor_test.go
@@ -5130,6 +5130,142 @@ func TestCheckMediaURLsHealthAndUpdateViewability_ViewabilityInfoNotFound(t *tes
 	assert.Contains(t, err.Error(), "token viewability info not found")
 }
 
+// ====================================================================================
+// CheckMediaURLsHealthAndUpdateViewability – WorkingURL propagation (Gap 1 fix)
+// ====================================================================================
+
+// TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_Propagates verifies that when
+// url_checker returns a WorkingURL (alternative gateway resolved), we call
+// UpdateMediaURLAndPropagate instead of UpdateTokenMediaHealthByURL, and the returned
+// HealthyURLs contains the working URL – not the original dead gateway URL.
+func TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_Propagates(t *testing.T) {
+	mocks := setupTestExecutor(t)
+	defer tearDownTestExecutor(mocks)
+
+	ctx := context.Background()
+	// Use a representative Tezos FA2 token CID matching the #96 repro pattern (not a credential).
+	tokenCID := "tezos-mainnet:fa2:KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE:468134" //nolint:gosec
+	// Repro: dead feralfile IPFS gateway URL
+	deadURL := "https://ipfs.feralfile.com/ipfs/QmPjZona8QEqqvSK5wfx5Wr9aCeVrow3kisRjU1yHQZdtd"
+	// Working alternate resolved by url_checker
+	workingURL := "https://ipfs.filebase.io/ipfs/QmPjZona8QEqqvSK5wfx5Wr9aCeVrow3kisRjU1yHQZdtd"
+
+	mocks.urlChecker.EXPECT().
+		Check(ctx, deadURL).
+		Return(uri.HealthCheckResult{
+			Status:     uri.HealthStatusHealthy,
+			WorkingURL: &workingURL,
+		})
+
+	// Expect propagation (not a simple health update on the dead URL)
+	mocks.store.EXPECT().
+		UpdateMediaURLAndPropagate(ctx, deadURL, workingURL).
+		Return(nil)
+
+	token := &schema.Token{ID: 1, TokenCID: tokenCID}
+	mocks.store.EXPECT().GetTokenByTokenCID(ctx, tokenCID).Return(token, nil)
+
+	changes := []store.TokenViewabilityChange{
+		{TokenID: token.ID, TokenCID: tokenCID, OldViewable: false, NewViewable: true},
+	}
+	mocks.store.EXPECT().BatchUpdateTokensViewability(ctx, []uint64{token.ID}).Return(changes, nil)
+
+	result, err := mocks.executor.CheckMediaURLsHealthAndUpdateViewability(ctx, tokenCID, []string{deadURL})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.IsViewable)
+	// HealthyURLs must contain the working URL so downstream media indexing targets it
+	assert.Equal(t, []string{workingURL}, result.HealthyURLs)
+}
+
+// TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_PropagateError_FallsBackToMarkHealthy
+// verifies that a propagation failure is non-fatal: the function falls back to marking the
+// original URL healthy and still returns a successful result.
+func TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_PropagateError_FallsBackToMarkHealthy(t *testing.T) {
+	mocks := setupTestExecutor(t)
+	defer tearDownTestExecutor(mocks)
+
+	ctx := context.Background()
+	tokenCID := "tezos-mainnet:fa2:KT1TEST:1" //nolint:gosec
+	originalURL := "https://ipfs.feralfile.com/ipfs/QmTEST1234"
+	workingURL := "https://ipfs.filebase.io/ipfs/QmTEST1234"
+
+	mocks.urlChecker.EXPECT().
+		Check(ctx, originalURL).
+		Return(uri.HealthCheckResult{
+			Status:     uri.HealthStatusHealthy,
+			WorkingURL: &workingURL,
+		})
+
+	// Propagation fails
+	mocks.store.EXPECT().
+		UpdateMediaURLAndPropagate(ctx, originalURL, workingURL).
+		Return(fmt.Errorf("db error"))
+
+	// Fallback: mark original URL healthy
+	mocks.store.EXPECT().
+		UpdateTokenMediaHealthByURL(ctx, originalURL, schema.MediaHealthStatusHealthy, nil).
+		Return(nil)
+
+	token := &schema.Token{ID: 2, TokenCID: tokenCID}
+	mocks.store.EXPECT().GetTokenByTokenCID(ctx, tokenCID).Return(token, nil)
+
+	changes := []store.TokenViewabilityChange{
+		{TokenID: token.ID, TokenCID: tokenCID, OldViewable: false, NewViewable: true},
+	}
+	mocks.store.EXPECT().BatchUpdateTokensViewability(ctx, []uint64{token.ID}).Return(changes, nil)
+
+	result, err := mocks.executor.CheckMediaURLsHealthAndUpdateViewability(ctx, tokenCID, []string{originalURL})
+
+	// Non-fatal: should still succeed
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.IsViewable)
+	// HealthyURLs contains the working URL even when propagation failed
+	assert.Equal(t, []string{workingURL}, result.HealthyURLs)
+}
+
+// TestCheckMediaURLsHealthAndUpdateViewability_WorkingURLSameAsOriginal_NoPropagation verifies
+// that when WorkingURL equals the original URL, we treat it as a normal healthy result
+// (no propagation call – same behavior as before the fix).
+func TestCheckMediaURLsHealthAndUpdateViewability_WorkingURLSameAsOriginal_NoPropagation(t *testing.T) {
+	mocks := setupTestExecutor(t)
+	defer tearDownTestExecutor(mocks)
+
+	ctx := context.Background()
+	tokenCID := "ethereum-mainnet:erc721:0x1234567890123456789012345678901234567890:1"
+	imageURL := "https://example.com/image.jpg"
+	// WorkingURL == original – no propagation expected
+	sameURL := imageURL
+
+	mocks.urlChecker.EXPECT().
+		Check(ctx, imageURL).
+		Return(uri.HealthCheckResult{
+			Status:     uri.HealthStatusHealthy,
+			WorkingURL: &sameURL,
+		})
+
+	// No UpdateMediaURLAndPropagate call expected – only the normal health update
+	mocks.store.EXPECT().
+		UpdateTokenMediaHealthByURL(ctx, imageURL, schema.MediaHealthStatusHealthy, nil).
+		Return(nil)
+
+	token := &schema.Token{ID: 3, TokenCID: tokenCID}
+	mocks.store.EXPECT().GetTokenByTokenCID(ctx, tokenCID).Return(token, nil)
+
+	changes := []store.TokenViewabilityChange{
+		{TokenID: token.ID, TokenCID: tokenCID, OldViewable: false, NewViewable: true},
+	}
+	mocks.store.EXPECT().BatchUpdateTokensViewability(ctx, []uint64{token.ID}).Return(changes, nil)
+
+	result, err := mocks.executor.CheckMediaURLsHealthAndUpdateViewability(ctx, tokenCID, []string{imageURL})
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsViewable)
+	assert.Equal(t, []string{imageURL}, result.HealthyURLs)
+}
+
 // TestIndexTokenWithFullProvenancesByTokenCID_SingleOwnerAdapterAuthority tests that for
 // configured single-owner Ethereum contracts, the adapter TokenOwner() method is the source
 // of truth for current ownership, even when parsed events indicate a different owner.

--- a/internal/workflows/core_executor_test.go
+++ b/internal/workflows/core_executor_test.go
@@ -5179,10 +5179,15 @@ func TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_Propagates(t *testi
 	assert.Equal(t, []string{workingURL}, result.HealthyURLs)
 }
 
-// TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_PropagateError_FallsBackToMarkHealthy
-// verifies that a propagation failure is non-fatal: the function falls back to marking the
-// original URL healthy and still returns a successful result.
-func TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_PropagateError_FallsBackToMarkHealthy(t *testing.T) {
+// TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_PropagateError_FallsBackToMarkBroken
+// verifies that when UpdateMediaURLAndPropagate fails, the original URL is recorded as broken
+// (not healthy) and no URL is added to HealthyURLs.
+//
+// Reason: the original URL failed the direct probe; only the alternate gateway worked.
+// Promoting the broken original to "healthy" would cause BatchUpdateTokensViewability to set
+// viewable=true while the read path still serves the dead gateway URL, reproducing bug #96.
+// The sweeper will retry propagation and fix the state.
+func TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_PropagateError_FallsBackToMarkBroken(t *testing.T) {
 	mocks := setupTestExecutor(t)
 	defer tearDownTestExecutor(mocks)
 
@@ -5203,27 +5208,30 @@ func TestCheckMediaURLsHealthAndUpdateViewability_WorkingURL_PropagateError_Fall
 		UpdateMediaURLAndPropagate(ctx, originalURL, workingURL).
 		Return(fmt.Errorf("db error"))
 
-	// Fallback: mark original URL healthy
+	// Fallback: mark original URL BROKEN (not healthy) — it failed the direct probe
 	mocks.store.EXPECT().
-		UpdateTokenMediaHealthByURL(ctx, originalURL, schema.MediaHealthStatusHealthy, nil).
+		UpdateTokenMediaHealthByURL(ctx, originalURL, schema.MediaHealthStatusBroken, nil).
 		Return(nil)
 
 	token := &schema.Token{ID: 2, TokenCID: tokenCID}
 	mocks.store.EXPECT().GetTokenByTokenCID(ctx, tokenCID).Return(token, nil)
 
+	// No healthy URLs → viewability not promoted based on the broken original URL.
+	// BatchUpdateTokensViewability is still called (it re-derives viewability from health rows).
 	changes := []store.TokenViewabilityChange{
-		{TokenID: token.ID, TokenCID: tokenCID, OldViewable: false, NewViewable: true},
+		{TokenID: token.ID, TokenCID: tokenCID, OldViewable: false, NewViewable: false},
 	}
 	mocks.store.EXPECT().BatchUpdateTokensViewability(ctx, []uint64{token.ID}).Return(changes, nil)
 
 	result, err := mocks.executor.CheckMediaURLsHealthAndUpdateViewability(ctx, tokenCID, []string{originalURL})
 
-	// Non-fatal: should still succeed
+	// Non-fatal: should still complete without error
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.True(t, result.IsViewable)
-	// HealthyURLs contains the working URL even when propagation failed
-	assert.Equal(t, []string{workingURL}, result.HealthyURLs)
+	// Token stays non-viewable: the broken original must not be promoted
+	assert.False(t, result.IsViewable)
+	// HealthyURLs is empty: propagation failed, no confirmed-healthy URL persisted
+	assert.Empty(t, result.HealthyURLs)
 }
 
 // TestCheckMediaURLsHealthAndUpdateViewability_WorkingURLSameAsOriginal_NoPropagation verifies


### PR DESCRIPTION
## Problem

Indexer-v2 can return `viewable: true` while `display.animation_url` points at a dead gateway URL (e.g. `ipfs.feralfile.com` → 404). FF1 loads `animation_url` first for generative works, causing black-screen playback failures ([#96](https://github.com/feral-file/ff-indexer-v2/issues/96)).

Two gaps:

1. **Read path:** `MergeTokenDisplay` serves raw metadata/enrichment URLs with no `token_media_health` filtering.
2. **Write path:** `CheckMediaURLsHealthAndUpdateViewability` ignored `WorkingURL` from the health checker (unlike the sweeper), so dead gateway URLs could be marked healthy without propagating reachable alternates.

## Why It Matters

This is a P0 customer-facing playback failure on FF1. Tokens appear playable in default playlist responses but hit black screens when the player loads a broken generative URL.

## Acceptance Checks

- [x] Repro token `tezos:mainnet:fa2:KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE:468134`: after fix, local `display.animation_url` is a reachable gateway (not dead feralfile); simulated production stale state serves healthy metadata URL instead of broken enrichment URL
- [x] When `token_media_health` has a healthy alternate and enrichment metadata still points at a broken gateway, API `display` serves the healthy URL (or omits the field when all animation URLs are broken)
- [x] Regression tests added for `ApplyHealthyMediaURLs`, `WorkingURL` propagation in indexing, and `GetTokenMediaHealthByTokenIDs`
- [x] Unviewable tokens remain `viewable: false` after indexing (verified locally for `eip155:1:erc721:0xb9b5…:668` and `eip155:1:erc721:0xB8bD…:1473`, matching production)

## Human Owner

@jollyjoker992

## How The Agent Will Be Used

Agent implemented the fix, added unit/integration tests, ran `make check`, and validated against production + local indexing for issue repro and unviewable-token parity.

## PR or Deploy Link

_TBD — this PR_

---

### Changes

- **`ApplyHealthyMediaURLs`** (`internal/api/shared/dto/token_display_health.go`): filters `display.image_url` / `display.animation_url` using `token_media_health` rows; omits broken URLs rather than serving dead gateways
- **`GetTokenMediaHealthByTokenIDs`**: bulk store query wired into `GetToken` / `GetTokens` display expansion
- **`CheckMediaURLsHealthAndUpdateViewability`**: propagates `WorkingURL` via `UpdateMediaURLAndPropagate` (parity with media health sweeper); `HealthyURLs` returns the reachable URL

### Verification

```bash
make check
```

Manual validation (local docker against shared postgres):

- Production confirmed bug on `…:468134` (`viewable: true`, dead feralfile `display.animation_url`)
- Local fresh index serves reachable gateway URLs; simulated stale DB state serves healthy metadata URL in `display`
- Two production-unviewable ERC-721 tokens indexed locally: `viewable: false` matches production; broken `display.image_url` omitted (intentional)

### Follow-up (out of scope)

- Production backfill: re-trigger metadata indexing for affected Tezos tokens with dead feralfile gateway pattern
- Optional Fix 3: tighten `BatchUpdateTokensViewability` to match canonical display URL semantics