### PR TITLE
fix(workflows): persist viewability when metadata has no media URLs

### DIFF
--- a/internal/workflows/core_executor.go
+++ b/internal/workflows/core_executor.go
@@ -622,6 +622,11 @@ func (e *coreExecutor) EnhanceTokenMetadata(ctx context.Context, tokenCID domain
 // marked broken (its true health state) and excluded from healthyURLs. The sweeper will eventually
 // retry UpdateMediaURLAndPropagate and fix the state. Marking it healthy would feed
 // BatchUpdateTokensViewability with false data, recreating the viewable=true + broken URL bug (#96).
+//
+// Constraints: BatchUpdateTokensViewability must always be called regardless of whether mediaURLs is
+// empty. Skipping it when there are no URLs leaves stale is_viewable=true rows uncorrected — a token
+// re-indexed after losing all media URLs would remain visible in default owner queries even though
+// both display URLs are empty.
 func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Context, tokenCID string, mediaURLs []string) (*MediaHealthCheckResult, error) {
 	logger.InfoCtx(ctx, "Checking media health and updating viewability",
 		zap.String("token_cid", tokenCID),
@@ -629,138 +634,134 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 		zap.Int("url_count", len(mediaURLs)),
 	)
 
-	// If no URLs to check, return false
-	if len(mediaURLs) == 0 {
-		return &MediaHealthCheckResult{
-			IsViewable:  false,
-			HealthyURLs: nil,
-		}, nil
-	}
-
-	// Use goroutines to check URLs in parallel
-	type urlResult struct {
-		url          string
-		workingURL   *string // non-nil when an alternative gateway resolved successfully
-		healthStatus schema.MediaHealthStatus
-		lastError    *string
-	}
-
-	resultsChan := make(chan urlResult, len(mediaURLs))
-	var wg sync.WaitGroup
-
-	// Launch goroutine for each URL
-	for _, url := range mediaURLs {
-		wg.Add(1)
-		go func(u string) {
-			defer wg.Done()
-
-			var status schema.MediaHealthStatus
-			var workingURL *string
-			var errMsg *string
-
-			if types.IsDataURI(u) {
-				result := e.dataURIChecker.Check(u)
-				if result.Valid {
-					status = schema.MediaHealthStatusHealthy
-				} else {
-					status = schema.MediaHealthStatusBroken
-					errMsg = result.Error
-				}
-			} else {
-				result := e.urlChecker.Check(ctx, u)
-				switch result.Status {
-				case uri.HealthStatusHealthy:
-					status = schema.MediaHealthStatusHealthy
-					// Capture the working URL if the checker resolved an alternative gateway.
-					// This happens when the original IPFS/Arweave/OnChFS gateway URL is dead
-					// but the CID is still reachable via another configured gateway.
-					if result.WorkingURL != nil && *result.WorkingURL != u {
-						workingURL = result.WorkingURL
-					}
-				case uri.HealthStatusBroken:
-					status = schema.MediaHealthStatusBroken
-				default:
-					status = schema.MediaHealthStatusUnknown
-				}
-				errMsg = result.Error
-			}
-
-			resultsChan <- urlResult{
-				url:          u,
-				workingURL:   workingURL,
-				healthStatus: status,
-				lastError:    errMsg,
-			}
-		}(url)
-	}
-
-	// Wait for all checks to complete
-	wg.Wait()
-	close(resultsChan)
-
-	// Collect results and filter healthy URLs
-	healthStatuses := make(map[string]schema.MediaHealthStatus)
-	healthyURLs := make([]string, 0, len(mediaURLs))
-
-	for result := range resultsChan {
-		healthStatuses[result.url] = result.healthStatus
-
-		if result.healthStatus == schema.MediaHealthStatusHealthy {
-			if result.workingURL != nil {
-				// Alternative gateway found: propagate the working URL atomically across
-				// token_media_health, token_metadata, and enrichment_sources so the API
-				// immediately serves the reachable URL. This is the same logic as the sweeper.
-				logger.InfoCtx(ctx, "Found working alternative URL during indexing health check",
-					zap.String("token_cid", tokenCID),
-					zap.String("original_url", result.url),
-					zap.String("working_url", *result.workingURL),
-				)
-				if err := e.store.UpdateMediaURLAndPropagate(ctx, result.url, *result.workingURL); err != nil {
-					logger.ErrorCtx(ctx, err,
-						zap.String("url", result.url),
-						zap.String("working_url", *result.workingURL),
-					)
-					// Propagation failed: mark the original URL as broken (it is broken — the
-					// direct probe failed and only the alternate gateway succeeded). Do NOT mark
-					// it healthy and do NOT add the working URL to healthyURLs.
-					// Reason: promoting a known-broken URL to healthy would feed
-					// BatchUpdateTokensViewability with false data, making viewable=true while
-					// the read path still serves the dead gateway URL — reproducing bug #96.
-					// The sweeper will retry UpdateMediaURLAndPropagate and fix the state.
-					if err2 := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusBroken, nil); err2 != nil {
-						logger.ErrorCtx(ctx, err2, zap.String("url", result.url))
-					}
-				} else {
-					// Propagation succeeded: the working URL is now canonical in health table,
-					// metadata, and enrichment_sources. Use it for downstream media indexing.
-					healthyURLs = append(healthyURLs, *result.workingURL)
-				}
-			} else {
-				// Original URL is directly reachable
-				if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusHealthy, nil); err != nil {
-					logger.ErrorCtx(ctx, err, zap.String("url", result.url))
-				}
-				healthyURLs = append(healthyURLs, result.url)
-			}
-		} else {
-			// Update media health in database for broken/unknown URLs
-			if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, result.healthStatus, result.lastError); err != nil {
-				logger.ErrorCtx(ctx, err, zap.String("url", result.url))
-			}
-		}
-	}
-
-	// Get token to update viewability
+	// Fetch the token first so we can always call BatchUpdateTokensViewability at the end,
+	// even when mediaURLs is empty. Without this, a previously-viewable token that loses all
+	// media URLs on re-index would never have its is_viewable flag corrected in the DB.
 	token, err := e.store.GetTokenByTokenCID(ctx, tokenCID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token: %w", err)
 	}
-
 	if token == nil {
 		return nil, domain.ErrTokenNotFound
 	}
 
-	// Update viewability
+	var healthyURLs []string
+
+	if len(mediaURLs) > 0 {
+		// Use goroutines to check URLs in parallel
+		type urlResult struct {
+			url          string
+			workingURL   *string // non-nil when an alternative gateway resolved successfully
+			healthStatus schema.MediaHealthStatus
+			lastError    *string
+		}
+
+		resultsChan := make(chan urlResult, len(mediaURLs))
+		var wg sync.WaitGroup
+
+		// Launch goroutine for each URL
+		for _, url := range mediaURLs {
+			wg.Add(1)
+			go func(u string) {
+				defer wg.Done()
+
+				var status schema.MediaHealthStatus
+				var workingURL *string
+				var errMsg *string
+
+				if types.IsDataURI(u) {
+					result := e.dataURIChecker.Check(u)
+					if result.Valid {
+						status = schema.MediaHealthStatusHealthy
+					} else {
+						status = schema.MediaHealthStatusBroken
+						errMsg = result.Error
+					}
+				} else {
+					result := e.urlChecker.Check(ctx, u)
+					switch result.Status {
+					case uri.HealthStatusHealthy:
+						status = schema.MediaHealthStatusHealthy
+						// Capture the working URL if the checker resolved an alternative gateway.
+						// This happens when the original IPFS/Arweave/OnChFS gateway URL is dead
+						// but the CID is still reachable via another configured gateway.
+						if result.WorkingURL != nil && *result.WorkingURL != u {
+							workingURL = result.WorkingURL
+						}
+					case uri.HealthStatusBroken:
+						status = schema.MediaHealthStatusBroken
+					default:
+						status = schema.MediaHealthStatusUnknown
+					}
+					errMsg = result.Error
+				}
+
+				resultsChan <- urlResult{
+					url:          u,
+					workingURL:   workingURL,
+					healthStatus: status,
+					lastError:    errMsg,
+				}
+			}(url)
+		}
+
+		// Wait for all checks to complete
+		wg.Wait()
+		close(resultsChan)
+
+		// Collect results and filter healthy URLs
+		healthyURLs = make([]string, 0, len(mediaURLs))
+
+		for result := range resultsChan {
+			if result.healthStatus == schema.MediaHealthStatusHealthy {
+				if result.workingURL != nil {
+					// Alternative gateway found: propagate the working URL atomically across
+					// token_media_health, token_metadata, and enrichment_sources so the API
+					// immediately serves the reachable URL. This is the same logic as the sweeper.
+					logger.InfoCtx(ctx, "Found working alternative URL during indexing health check",
+						zap.String("token_cid", tokenCID),
+						zap.String("original_url", result.url),
+						zap.String("working_url", *result.workingURL),
+					)
+					if err := e.store.UpdateMediaURLAndPropagate(ctx, result.url, *result.workingURL); err != nil {
+						logger.ErrorCtx(ctx, err,
+							zap.String("url", result.url),
+							zap.String("working_url", *result.workingURL),
+						)
+						// Propagation failed: mark the original URL as broken (it is broken — the
+						// direct probe failed and only the alternate gateway succeeded). Do NOT mark
+						// it healthy and do NOT add the working URL to healthyURLs.
+						// Reason: promoting a known-broken URL to healthy would feed
+						// BatchUpdateTokensViewability with false data, making viewable=true while
+						// the read path still serves the dead gateway URL — reproducing bug #96.
+						// The sweeper will retry UpdateMediaURLAndPropagate and fix the state.
+						if err2 := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusBroken, nil); err2 != nil {
+							logger.ErrorCtx(ctx, err2, zap.String("url", result.url))
+						}
+					} else {
+						// Propagation succeeded: the working URL is now canonical in health table,
+						// metadata, and enrichment_sources. Use it for downstream media indexing.
+						healthyURLs = append(healthyURLs, *result.workingURL)
+					}
+				} else {
+					// Original URL is directly reachable
+					if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, schema.MediaHealthStatusHealthy, nil); err != nil {
+						logger.ErrorCtx(ctx, err, zap.String("url", result.url))
+					}
+					healthyURLs = append(healthyURLs, result.url)
+				}
+			} else {
+				// Update media health in database for broken/unknown URLs
+				if err := e.store.UpdateTokenMediaHealthByURL(ctx, result.url, result.healthStatus, result.lastError); err != nil {
+					logger.ErrorCtx(ctx, err, zap.String("url", result.url))
+				}
+			}
+		}
+	}
+
+	// Always update viewability against token_media_health rows.
+	// When mediaURLs is empty, no health rows exist for the token, so BatchUpdateTokensViewability
+	// will correctly compute is_viewable=false and persist it — fixing any stale true value.
 	changes, err := e.store.BatchUpdateTokensViewability(ctx, []uint64{token.ID})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update token viewability: %w", err)
@@ -774,8 +775,8 @@ func (e *coreExecutor) CheckMediaURLsHealthAndUpdateViewability(ctx context.Cont
 		}, nil
 	}
 
-	// If no changes, the viewability status didn't change
-	// We need to query the current status to return the correct value
+	// If no changes, the viewability status didn't change.
+	// Query the current value to return it accurately.
 	viewabilityInfo, err := e.store.GetTokensViewabilityByIDs(ctx, []uint64{token.ID})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token viewability: %w", err)

--- a/internal/workflows/core_executor_test.go
+++ b/internal/workflows/core_executor_test.go
@@ -4848,6 +4848,10 @@ func TestCheckMediaURLsHealthAndUpdateViewability_Success_UnknownStatus(t *testi
 	assert.Equal(t, 0, len(result.HealthyURLs))
 }
 
+// TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList verifies that when there are no media
+// URLs the function still persists is_viewable=false via BatchUpdateTokensViewability.
+// Previously the function returned early without touching the DB, leaving a stale is_viewable=true
+// value uncorrected for tokens that lost all media URLs between indexing runs.
 func TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList(t *testing.T) {
 	mocks := setupTestExecutor(t)
 	defer tearDownTestExecutor(mocks)
@@ -4856,7 +4860,27 @@ func TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList(t *testing.T) {
 	tokenCID := "ethereum-mainnet:erc721:0x1234567890123456789012345678901234567890:1"
 	mediaURLs := []string{}
 
-	// No URLs to check, should return false
+	token := &schema.Token{
+		ID:       uint64(123),
+		TokenCID: tokenCID,
+	}
+	mocks.store.EXPECT().
+		GetTokenByTokenCID(ctx, tokenCID).
+		Return(token, nil)
+
+	// No health rows exist for this token, so BatchUpdateTokensViewability computes
+	// is_viewable=false. It was previously true (stale), so a change is recorded.
+	changes := []store.TokenViewabilityChange{
+		{
+			TokenID:     token.ID,
+			TokenCID:    tokenCID,
+			OldViewable: true,
+			NewViewable: false,
+		},
+	}
+	mocks.store.EXPECT().
+		BatchUpdateTokensViewability(ctx, []uint64{token.ID}).
+		Return(changes, nil)
 
 	result, err := mocks.executor.CheckMediaURLsHealthAndUpdateViewability(ctx, tokenCID, mediaURLs)
 
@@ -4866,29 +4890,70 @@ func TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList(t *testing.T) {
 	assert.Equal(t, 0, len(result.HealthyURLs))
 }
 
+// TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList_AlreadyUnviewable verifies that when
+// the token is already unviewable and there are no URLs, the function returns false without error.
+func TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList_AlreadyUnviewable(t *testing.T) {
+	mocks := setupTestExecutor(t)
+	defer tearDownTestExecutor(mocks)
+
+	ctx := context.Background()
+	tokenCID := "ethereum-mainnet:erc721:0x1234567890123456789012345678901234567890:1"
+
+	token := &schema.Token{ID: uint64(456), TokenCID: tokenCID}
+	mocks.store.EXPECT().
+		GetTokenByTokenCID(ctx, tokenCID).
+		Return(token, nil)
+
+	// No change — token was already is_viewable=false.
+	mocks.store.EXPECT().
+		BatchUpdateTokensViewability(ctx, []uint64{token.ID}).
+		Return([]store.TokenViewabilityChange{}, nil)
+
+	viewabilityInfo := []store.TokenViewabilityInfo{{TokenID: token.ID, TokenCID: tokenCID, IsViewable: false}}
+	mocks.store.EXPECT().
+		GetTokensViewabilityByIDs(ctx, []uint64{token.ID}).
+		Return(viewabilityInfo, nil)
+
+	result, err := mocks.executor.CheckMediaURLsHealthAndUpdateViewability(ctx, tokenCID, []string{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.False(t, result.IsViewable)
+	assert.Empty(t, result.HealthyURLs)
+}
+
+// TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList_TokenNotFound verifies that when there
+// are no media URLs and the token does not exist, the function returns ErrTokenNotFound.
+func TestCheckMediaURLsHealthAndUpdateViewability_EmptyURLList_TokenNotFound(t *testing.T) {
+	mocks := setupTestExecutor(t)
+	defer tearDownTestExecutor(mocks)
+
+	ctx := context.Background()
+	tokenCID := "ethereum-mainnet:erc721:0x1234567890123456789012345678901234567890:1"
+
+	mocks.store.EXPECT().
+		GetTokenByTokenCID(ctx, tokenCID).
+		Return(nil, nil)
+
+	result, err := mocks.executor.CheckMediaURLsHealthAndUpdateViewability(ctx, tokenCID, []string{})
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, domain.ErrTokenNotFound, err)
+}
+
+// TestCheckMediaURLsHealthAndUpdateViewability_TokenNotFound verifies that when the token does not
+// exist in the DB, the function returns ErrTokenNotFound without probing any URLs.
+// The token lookup is now the first DB operation so URL checks never run.
 func TestCheckMediaURLsHealthAndUpdateViewability_TokenNotFound(t *testing.T) {
 	mocks := setupTestExecutor(t)
 	defer tearDownTestExecutor(mocks)
 
 	ctx := context.Background()
 	tokenCID := "ethereum-mainnet:erc721:0x1234567890123456789012345678901234567890:1"
-	imageURL := "https://example.com/image.jpg"
-	mediaURLs := []string{imageURL}
+	mediaURLs := []string{"https://example.com/image.jpg"}
 
-	// Mock URL health check
-	mocks.urlChecker.EXPECT().
-		Check(ctx, imageURL).
-		Return(uri.HealthCheckResult{
-			Status: uri.HealthStatusHealthy,
-			Error:  nil,
-		})
-
-	// Mock database update for media health
-	mocks.store.EXPECT().
-		UpdateTokenMediaHealthByURL(ctx, imageURL, schema.MediaHealthStatusHealthy, nil).
-		Return(nil)
-
-	// Mock token retrieval - not found
+	// Token lookup is now first; URL checks never run.
 	mocks.store.EXPECT().
 		GetTokenByTokenCID(ctx, tokenCID).
 		Return(nil, nil)
@@ -4900,30 +4965,18 @@ func TestCheckMediaURLsHealthAndUpdateViewability_TokenNotFound(t *testing.T) {
 	assert.Equal(t, domain.ErrTokenNotFound, err)
 }
 
+// TestCheckMediaURLsHealthAndUpdateViewability_GetTokenError verifies that a DB error on the token
+// lookup is returned immediately without probing any URLs.
 func TestCheckMediaURLsHealthAndUpdateViewability_GetTokenError(t *testing.T) {
 	mocks := setupTestExecutor(t)
 	defer tearDownTestExecutor(mocks)
 
 	ctx := context.Background()
 	tokenCID := "ethereum-mainnet:erc721:0x1234567890123456789012345678901234567890:1"
-	imageURL := "https://example.com/image.jpg"
-	mediaURLs := []string{imageURL}
+	mediaURLs := []string{"https://example.com/image.jpg"}
 	dbError := errors.New("database connection error")
 
-	// Mock URL health check
-	mocks.urlChecker.EXPECT().
-		Check(ctx, imageURL).
-		Return(uri.HealthCheckResult{
-			Status: uri.HealthStatusHealthy,
-			Error:  nil,
-		})
-
-	// Mock database update for media health
-	mocks.store.EXPECT().
-		UpdateTokenMediaHealthByURL(ctx, imageURL, schema.MediaHealthStatusHealthy, nil).
-		Return(nil)
-
-	// Mock token retrieval - error
+	// Token lookup is now first; URL checks never run.
 	mocks.store.EXPECT().
 		GetTokenByTokenCID(ctx, tokenCID).
 		Return(nil, dbError)


### PR DESCRIPTION
## Problem

`CheckMediaURLsHealthAndUpdateViewability` returned early when `mediaURLs` was empty, reporting `IsViewable: false` to the caller but never calling `BatchUpdateTokensViewability`. Tokens that previously had `is_viewable=true` stayed visible in default owner queries (`include_unviewable=false`) even after re-indexing with empty `image_url` and `animation_url`.

Observed on production for `tezos:mainnet:fa2:KT1WLqrZGc5Nm2tGm5Vd1xqphhsGhN84A9rS:0` (tPICLES): fungible FA2 metadata has only `thumbnailUri` (inline base64), no `displayUri`/`artifactUri`, Objkt enrichment returns not found, so metadata indexing yields zero media URLs and the stale `viewable: true` flag was never corrected.

## Why It Matters

Default token list queries filter on `is_viewable=true`. Stale viewability causes unviewable tokens (no display media) to appear in owner collections, which breaks the intended contract for FF1 and downstream clients that rely on viewability filtering.

## Acceptance Checks

- [x] `CheckMediaURLsHealthAndUpdateViewability` always calls `BatchUpdateTokensViewability`, including when `mediaURLs` is empty
- [x] Empty-URL path corrects stale `is_viewable=true` to `false` when no healthy `token_media_health` rows exist
- [x] Token-not-found and DB error paths fail before URL probing (token lookup moved first)
- [x] All 17 `TestCheckMediaURLsHealthAndUpdateViewability_*` tests pass
- [x] `make check` passes locally

## Human Owner

@jollyjoker992

## How The Agent Will Be Used

Agent traced the tPICLES token through local indexing and production API queries, identified the early-return gap in `core_executor.go`, implemented the fix (fetch token first, always run `BatchUpdateTokensViewability`), updated/added unit tests, and ran `make check`.

## PR or Deploy Link

This PR.

## Follow-up (out of scope)

- Production backfill: re-index affected tokens (e.g. `POST /api/v1/tokens/index` for tPICLES) or run a one-off viewability sweep after deploy
- Optional: map FA2 `thumbnailUri` to `image_url` for fungible tokens (separate product decision)