### PR TITLE
fix(jobs,media): gate job claims and break resvg crash loop (#94)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -397,7 +397,18 @@ psql -h localhost -U postgres -d ff_indexer -c "SELECT * FROM key_value_store WH
 
 Work is stored in the **`jobs`** table (`queue`, `kind`, `status`, `payload`, `unique_key`, `run_after`, …). See [`docs/schema.md`](../docs/schema.md#jobs) for the full state machine and indexes.
 
-**No automatic retry (v1).** A handler error sets **`failed`** and **`last_error`**. The service does not apply exponential backoff or re-drive failed rows automatically. Webhook deliveries are also single-shot for delivery semantics; `webhook_clients.retry_max_attempts` is retained in the schema/API for compatibility but is not used to retry delivery. Operators **re-enqueue** work (e.g. new API trigger or ingestion event) or fix configuration/upstreams, then watch new jobs succeed.
+**No automatic retry (v1) — except crash recovery.** A handler error sets **`failed`** and **`last_error`**. The service does not apply exponential backoff or re-drive failed rows automatically. Webhook deliveries are also single-shot for delivery semantics; `webhook_clients.retry_max_attempts` is retained in the schema/API for compatibility but is not used to retry delivery. Operators **re-enqueue** work (e.g. new API trigger or ingestion event) or fix configuration/upstreams, then watch new jobs succeed.
+
+**Bounded crash-loop recovery.** Jobs left `running` after a process crash are swept by `SweepOrphanedJobs` on worker startup. The `jobs.attempt_count` column (incremented on each claim, reset to 0 on clean reschedule) determines the outcome:
+
+- `attempt_count < max_attempts` → reset to `pending` for retry (default: up to 3 attempts total).
+- `attempt_count >= max_attempts` → permanently `failed` with `last_error = "crash-loop terminated: ..."`.
+
+This breaks infinite loops caused by CGO/Rust panics (e.g. resvg SIGABRT on certain SVG filter primitives) that kill the process before the job can be marked failed. `max_attempts` is operator-tunable via `FF_INDEXER_JOBS_TOKEN_WORKER_MAX_ATTEMPTS` and `FF_INDEXER_JOBS_MEDIA_WORKER_MAX_ATTEMPTS` (default 3).
+
+**Claim backpressure.** Workers claim at most `min(concurrency - in_use, batch_size)` jobs per poll tick. This keeps DB `running` counts aligned with actual executing goroutines and prevents inflating observable queue health metrics.
+
+See [`docs/schema.md`](../docs/schema.md#jobs) for the full state machine and `attempt_count` semantics.
 
 **Claiming and scaling.** At runtime, workers **poll** for `pending` jobs ready by `run_after` and **claim** them inside a database transaction with **`SELECT … FOR UPDATE SKIP LOCKED`**, so different sessions can claim different rows without waiting on each other’s row locks. A **per-queue advisory lock** (`pg_try_advisory_lock` on a hash of the queue name) ensures only one process in the default model **polls** a given `queue` name; do not start multiple competing pollers for the same queue name without a deliberate operational plan.
 

--- a/cmd/ff-indexer/config.yaml.sample
+++ b/cmd/ff-indexer/config.yaml.sample
@@ -46,11 +46,15 @@ jobs:
     poll_interval: 2s
     batch_size: 16
     cancel_interval: 5s
+    # Max consecutive crash/orphan attempts before SweepOrphanedJobs permanently fails the job.
+    # Clean reschedules (ErrReschedule) reset this counter. Default: 3.
+    max_attempts: 3
   media_worker:
     concurrency: 10
     poll_interval: 2s
     batch_size: 16
     cancel_interval: 5s
+    max_attempts: 3
 
 # Set true only when running the CGO/full media path with Cloudflare credentials configured.
 media_enabled: false

--- a/cmd/ff-indexer/worker_core.go
+++ b/cmd/ff-indexer/worker_core.go
@@ -207,6 +207,7 @@ func registerWorkerCore(
 		PollInterval:   tw.PollInterval,
 		BatchSize:      tw.BatchSize,
 		CancelInterval: tw.CancelInterval,
+		MaxAttempts:    tw.MaxAttempts,
 	})
 
 	// Run blocks until worker exits or ctx is canceled; cleanup closes the Ethereum RPC client.

--- a/cmd/ff-indexer/worker_media.go
+++ b/cmd/ff-indexer/worker_media.go
@@ -121,6 +121,7 @@ func registerWorkerMedia(
 		PollInterval:   mw.PollInterval,
 		BatchSize:      mw.BatchSize,
 		CancelInterval: mw.CancelInterval,
+		MaxAttempts:    mw.MaxAttempts,
 	})
 
 	// Run until worker stops or ctx is canceled; cleanup closes transform resources.

--- a/config/.env
+++ b/config/.env
@@ -55,11 +55,16 @@ FF_INDEXER_JOBS_TOKEN_WORKER_CONCURRENCY=2
 FF_INDEXER_JOBS_TOKEN_WORKER_POLL_INTERVAL=2s
 FF_INDEXER_JOBS_TOKEN_WORKER_BATCH_SIZE=100
 FF_INDEXER_JOBS_TOKEN_WORKER_CANCEL_INTERVAL=5s
+# Max consecutive process-crash attempts before SweepOrphanedJobs permanently fails a job.
+# Clean reschedules (e.g. quota reset via ErrReschedule) reset the counter, so this only
+# counts genuine crashes (SIGABRT/OOM). Default: 3.
+FF_INDEXER_JOBS_TOKEN_WORKER_MAX_ATTEMPTS=3
 # media_index worker (poll loop)
 FF_INDEXER_JOBS_MEDIA_WORKER_CONCURRENCY=1
 FF_INDEXER_JOBS_MEDIA_WORKER_POLL_INTERVAL=2s
 FF_INDEXER_JOBS_MEDIA_WORKER_BATCH_SIZE=200
 FF_INDEXER_JOBS_MEDIA_WORKER_CANCEL_INTERVAL=5s
+FF_INDEXER_JOBS_MEDIA_WORKER_MAX_ATTEMPTS=3
 
 # ----------------
 # Ethereum Configuration

--- a/db/init_pg_db.sql
+++ b/db/init_pg_db.sql
@@ -318,6 +318,7 @@ CREATE TABLE jobs (
     run_after TIMESTAMPTZ NOT NULL DEFAULT now(),
     last_error TEXT,
     cancel_requested BOOLEAN NOT NULL DEFAULT false,
+    attempt_count INTEGER NOT NULL DEFAULT 0, -- incremented on each claim; used by SweepOrphanedJobs to break crash loops
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     started_at TIMESTAMPTZ,

--- a/db/migrations/020.sql
+++ b/db/migrations/020.sql
@@ -1,0 +1,24 @@
+-- Migration 020: Add attempt_count to jobs for crash-loop protection.
+--
+-- Without this column, SweepOrphanedJobs unconditionally resets every running row back to
+-- pending on worker startup. A job that crashes the process via SIGABRT (e.g. an SVG whose
+-- resvg filter triggers a Rust assertion) would loop forever: run → SIGABRT → orphan →
+-- sweep → pending → run → SIGABRT ...
+--
+-- With attempt_count, ClaimJobs increments the counter on every claim. SweepOrphanedJobs
+-- can compare against a configured MaxAttempts threshold and transition exhausted jobs to
+-- failed instead of resetting them to pending, breaking the loop permanently.
+--
+-- Default 0: existing rows start with no recorded attempts (treated as fresh by workers).
+
+BEGIN;
+
+ALTER TABLE jobs
+    ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN jobs.attempt_count IS
+    'Number of times this job has been claimed (incremented by ClaimJobs). '
+    'SweepOrphanedJobs uses this to mark jobs failed after MaxAttempts crashes '
+    'instead of resetting them to pending indefinitely.';
+
+COMMIT;

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -438,6 +438,7 @@ Durable work queue: one row per unit of background work. Logical queues (e.g. `t
 | run_after | TIMESTAMPTZ | Do not run before this time (scheduling, quota resume, operator reschedule) |
 | last_error | TEXT | Set when a handler fails (terminal for `failed` status) |
 | cancel_requested | BOOLEAN | Worker observes this and cancels the handler context |
+| attempt_count | INTEGER | Incremented each time the job is claimed by a worker; reset to 0 on clean reschedule. Used by `SweepOrphanedJobs` to detect crash loops: a job orphaned (left running after a process crash) with `attempt_count >= max_attempts` is permanently failed instead of reset to pending. |
 | created_at | TIMESTAMPTZ | Row creation time |
 | updated_at | TIMESTAMPTZ | Last update time |
 | started_at | TIMESTAMPTZ | When a worker claimed the job |
@@ -454,11 +455,13 @@ Workers **claim** work in PostgreSQL using a transaction that selects candidate 
 
 **State machine (v1)**:
 
-- **`pending` → `running`**: on successful claim by a worker.
+- **`pending` → `running`**: on successful claim by a worker. `attempt_count` is incremented atomically.
 - **`running` → `succeeded`**: handler returns with no error.
 - **`running` → `failed`**: handler returns an error (other than a controlled reschedule sentinel). `last_error` is populated. **There is no automatic retry**: operators must re-enqueue or fix upstream and enqueue again.
-- **`running` → `pending`**: handler requests reschedule (e.g. quota not yet reset) with a new `run_after` time.
-- **Startup / crash recovery**: rows left `running` (e.g. after process death) are swept back to **`pending`** with cleared `started_at` so they can be claimed again. This is a deliberate trade-off: a handler that was mid-flight may run twice; idempotent handlers and dedup keys mitigate duplicates.
+- **`running` → `pending`** (clean reschedule): handler requests reschedule (e.g. quota not yet reset) with a new `run_after` time. `attempt_count` is **reset to 0** because the handler ran and made a deliberate retry decision — this does not count as a crash.
+- **Startup / crash recovery** (`SweepOrphanedJobs`): rows left `running` after process death are evaluated by `attempt_count` vs the configured `max_attempts` (default 3):
+  - `attempt_count < max_attempts` → reset to **`pending`** for retry. The job may run twice; idempotent handlers and dedup keys mitigate duplicates.
+  - `attempt_count >= max_attempts` → permanently **`failed`** with `last_error = "crash-loop terminated: ..."`. This breaks infinite crash loops (e.g. an SVG with `feDisplacementMap` triggering a Rust assertion in resvg via CGO — SIGABRT kills the process before the job can be marked failed, so the sweep must make it terminal). `max_attempts` is operator-tunable via `FF_INDEXER_JOBS_{TOKEN,MEDIA}_WORKER_MAX_ATTEMPTS`.
 - **Cancel**: `cancel_requested` is set; the worker cancels the handler context and drives the row to **`canceled`**.
 
 **Relationships**:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,9 @@ type WorkerPoolConfig struct {
 	PollInterval   time.Duration `mapstructure:"poll_interval"`
 	BatchSize      int           `mapstructure:"batch_size"`
 	CancelInterval time.Duration `mapstructure:"cancel_interval"`
+	// MaxAttempts is the maximum number of times a job may be claimed before it is permanently
+	// failed by SweepOrphanedJobs. This breaks the crash loop caused by CGO/Rust SIGABRT panics.
+	MaxAttempts int `mapstructure:"max_attempts"`
 }
 
 // JobsConfig holds job queue names and worker pool settings for token_index and media_index.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -520,10 +520,12 @@ func applyAppConfigDefaults(v *viper.Viper) {
 	v.SetDefault("jobs.token_worker.poll_interval", 2*time.Second)
 	v.SetDefault("jobs.token_worker.batch_size", 100)
 	v.SetDefault("jobs.token_worker.cancel_interval", 5*time.Second)
+	v.SetDefault("jobs.token_worker.max_attempts", 3)
 	v.SetDefault("jobs.media_worker.concurrency", 2)
 	v.SetDefault("jobs.media_worker.poll_interval", 2*time.Second)
 	v.SetDefault("jobs.media_worker.batch_size", 100)
 	v.SetDefault("jobs.media_worker.cancel_interval", 5*time.Second)
+	v.SetDefault("jobs.media_worker.max_attempts", 3)
 
 	v.SetDefault("media_enabled", false)
 	v.SetDefault("video_processing_enabled", false)
@@ -682,10 +684,12 @@ func bindAllEnvVars(v *viper.Viper) {
 		"jobs.token_worker.poll_interval",
 		"jobs.token_worker.batch_size",
 		"jobs.token_worker.cancel_interval",
+		"jobs.token_worker.max_attempts",
 		"jobs.media_worker.concurrency",
 		"jobs.media_worker.poll_interval",
 		"jobs.media_worker.batch_size",
 		"jobs.media_worker.cancel_interval",
+		"jobs.media_worker.max_attempts",
 		"media_enabled",
 		"video_processing_enabled",
 		// Vendors

--- a/internal/media/processor/processor.go
+++ b/internal/media/processor/processor.go
@@ -495,6 +495,16 @@ func (p *processor) processSVGBytes(ctx context.Context, svgData []byte, origina
 
 	pngData, err := p.rasterizer.Rasterize(ctx, svgData)
 	if err != nil {
+		// ErrUnsupportedSVGFilter means the SVG contains filter primitives (e.g. feDisplacementMap)
+		// that would crash resvg at the OS level (SIGABRT) and no browser renderer is available.
+		// Treat as unsupported so the job is skipped cleanly rather than retried indefinitely
+		// after each process restart via SweepOrphanedJobs.
+		if errors.Is(err, rasterizer.ErrUnsupportedSVGFilter) {
+			logger.WarnCtx(ctx, "SVG uses unsupported filter primitives; skipping media indexing",
+				zap.Error(err),
+			)
+			return nil, "", 0, domain.ErrUnsupportedMediaFile
+		}
 		logger.ErrorCtx(ctx, err)
 		return nil, "", 0, fmt.Errorf("failed to rasterize SVG: %w", err)
 	}

--- a/internal/media/processor/processor.go
+++ b/internal/media/processor/processor.go
@@ -495,17 +495,12 @@ func (p *processor) processSVGBytes(ctx context.Context, svgData []byte, origina
 
 	pngData, err := p.rasterizer.Rasterize(ctx, svgData)
 	if err != nil {
-		// ErrUnsupportedSVGFilter means the SVG contains filter primitives (e.g. feDisplacementMap)
-		// that would crash resvg at the OS level (SIGABRT) and no browser renderer is available.
-		// Treat as unsupported so the job is skipped cleanly rather than retried indefinitely
-		// after each process restart via SweepOrphanedJobs.
-		if errors.Is(err, rasterizer.ErrUnsupportedSVGFilter) {
-			logger.WarnCtx(ctx, "SVG uses unsupported filter primitives; skipping media indexing",
-				zap.Error(err),
-			)
-			return nil, "", 0, domain.ErrUnsupportedMediaFile
-		}
 		logger.ErrorCtx(ctx, err)
+		// ErrUnsupportedSVGFilter: the SVG contains a filter primitive (e.g. feDisplacementMap)
+		// that would SIGABRT resvg and no browser renderer is available. Propagate as a real
+		// error so the job is marked failed with last_error set, making it operationally visible.
+		// Do NOT map to ErrUnsupportedMediaFile — the executor swallows that sentinel as a
+		// successful skip, hiding the failure from operators and Codecov.
 		return nil, "", 0, fmt.Errorf("failed to rasterize SVG: %w", err)
 	}
 

--- a/internal/media/processor/processor_test.go
+++ b/internal/media/processor/processor_test.go
@@ -13,9 +13,11 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/feral-file/ff-indexer-v2/internal/adapter"
+	"github.com/feral-file/ff-indexer-v2/internal/downloader"
 	"github.com/feral-file/ff-indexer-v2/internal/logger"
 	"github.com/feral-file/ff-indexer-v2/internal/media/processor"
 	mediaprovider "github.com/feral-file/ff-indexer-v2/internal/media/provider"
+	"github.com/feral-file/ff-indexer-v2/internal/media/rasterizer"
 	"github.com/feral-file/ff-indexer-v2/internal/media/transformer"
 	"github.com/feral-file/ff-indexer-v2/internal/mocks"
 	"github.com/feral-file/ff-indexer-v2/internal/store"
@@ -245,4 +247,68 @@ func TestProcess_VideoEnabled(t *testing.T) {
 	)
 
 	require.NoError(t, proc.Process(ctx, videoURL))
+}
+
+// TestProcess_SVGUnsupportedFilter verifies that ErrUnsupportedSVGFilter (returned by the
+// rasterizer when an SVG contains feDisplacementMap and no browser is available) propagates
+// as a real error from processor.Process. The job must be marked failed with last_error set,
+// NOT silently swallowed as a successful skip — which would hide the failure from operators.
+func TestProcess_SVGUnsupportedFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	jsonAdapter := adapter.NewJSON()
+	svgURL := "https://example.com/crash.svg"
+
+	httpClient := mocks.NewMockHTTPClient(ctrl)
+	uriResolver := mocks.NewMockURIResolver(ctrl)
+	dataChecker := mocks.NewMockDataURIChecker(ctrl)
+	st := mocks.NewMockStore(ctrl)
+	raster := mocks.NewMockRasterizer(ctrl)
+	fs := mocks.NewMockFileSystem(ctrl)
+	ioAdapter := mocks.NewMockIO(ctrl)
+	dl := mocks.NewMockDownloader(ctrl)
+	trans := mocks.NewMockTransformer(ctrl)
+	provider := mocks.NewMockMediaProvider(ctrl)
+
+	provider.EXPECT().Name().Return("cloudflare").AnyTimes()
+
+	httpClient.EXPECT().Head(gomock.Any(), svgURL).Return(&http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{"image/svg+xml"}},
+		ContentLength: 512,
+		Body:          io.NopCloser(strings.NewReader("")),
+	}, nil)
+
+	svgBody := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feDisplacementMap in="SourceGraphic" scale="10"/></filter></svg>`)
+	dl.EXPECT().Download(gomock.Any(), svgURL).Return(
+		&downloader.DownloadResult{}, nil,
+	)
+	ioAdapter.EXPECT().ReadAll(gomock.Any()).Return(svgBody, nil)
+
+	// Rasterizer returns ErrUnsupportedSVGFilter (feDisplacementMap + no browser).
+	raster.EXPECT().Rasterize(gomock.Any(), svgBody).Return(nil, rasterizer.ErrUnsupportedSVGFilter)
+
+	proc := processor.NewProcessor(
+		httpClient,
+		uriResolver,
+		dataChecker,
+		provider,
+		st,
+		raster,
+		fs,
+		ioAdapter,
+		jsonAdapter,
+		dl,
+		trans,
+		10*1024*1024,
+		300*1024*1024,
+		false,
+	)
+
+	err := proc.Process(ctx, svgURL)
+	// Must propagate as a real error so the caller marks the job failed, not succeeded.
+	require.Error(t, err, "ErrUnsupportedSVGFilter must not be silently swallowed as success")
+	require.ErrorIs(t, err, rasterizer.ErrUnsupportedSVGFilter)
 }

--- a/internal/media/rasterizer/rasterizer.go
+++ b/internal/media/rasterizer/rasterizer.go
@@ -5,8 +5,10 @@ package rasterizer
 import (
 	"bytes"
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"go.uber.org/zap"
@@ -113,17 +115,36 @@ func (r *rasterizer) Rasterize(ctx context.Context, svgData []byte) ([]byte, err
 	return r.rasterizeWithResvg(ctx, svgData)
 }
 
-// willCrashResvg reports whether the SVG contains feDisplacementMap, the only filter primitive
-// confirmed to trigger a fatal Rust assertion in resvg (SIGABRT via CGO). Such SVGs must never
-// reach resvg.Render because an OS abort cannot be caught by Go's recover().
+// willCrashResvg reports whether the SVG contains a <feDisplacementMap> XML element, the only
+// filter primitive confirmed to trigger a fatal Rust assertion in resvg (SIGABRT via CGO).
+// Such SVGs must never reach resvg.Render because an OS abort cannot be caught by Go's recover().
 //
 // feDisplacementMap asserts that source, map, and dest buffers share the same width; certain
-// SVG inputs violate this and cause: "assertion failed: src.width == map.width" → SIGABRT.
+// SVG inputs violate this: "assertion failed: src.width == map.width" → SIGABRT.
 // See linebender/resvg#1007, #1019, #1021. feTurbulence and feComposite are handled separately
-// in requiresBrowserRendering — they degrade without crashing, so hard-blocking them would
-// silently skip valid SVGs when no browser is available.
+// in requiresBrowserRendering — they degrade without crashing.
+//
+// Detection is XML-aware: the string "feDisplacementMap" appearing only in a comment, <desc>,
+// or other text content does not trigger this guard and the SVG reaches resvg normally.
+// On XML parse failure (malformed SVG), falls back to conservative byte matching — over-blocking
+// one edge-case SVG is preferable to missing a real element and letting resvg SIGABRT.
 func willCrashResvg(svgData []byte) bool {
-	return strings.Contains(string(svgData), "feDisplacementMap")
+	dec := xml.NewDecoder(bytes.NewReader(svgData))
+	dec.Strict = false
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			return false
+		}
+		if err != nil {
+			// Malformed XML: conservative fallback — string match so a real feDisplacementMap
+			// element in an otherwise unparseable SVG is never silently missed.
+			return bytes.Contains(svgData, []byte("feDisplacementMap"))
+		}
+		if se, ok := tok.(xml.StartElement); ok && se.Name.Local == "feDisplacementMap" {
+			return true
+		}
+	}
 }
 
 // requiresBrowserRendering analyzes SVG content to determine if browser rendering is preferred.

--- a/internal/media/rasterizer/rasterizer.go
+++ b/internal/media/rasterizer/rasterizer.go
@@ -117,7 +117,7 @@ func (r *rasterizer) Rasterize(ctx context.Context, svgData []byte) ([]byte, err
 	return r.rasterizeWithResvg(ctx, svgData)
 }
 
-// willCrashResvg reports whether the SVG contains filter primitives known to trigger a fatal
+// willCrashResvg reports whether the SVG contains filter primitives confirmed to trigger a fatal
 // Rust assertion in resvg (SIGABRT). These SVGs must never reach resvg.Render because an OS
 // abort cannot be caught by Go's recover() — it terminates the entire process.
 //
@@ -129,29 +129,24 @@ func (r *rasterizer) Rasterize(ctx context.Context, svgData []byte) ([]byte, err
 //	fatal runtime error: failed to initiate panic, error 5
 //	SIGABRT: abort
 //
-// Trade-offs: String matching is conservative (false-positive safe — over-routing to the browser
-// is better than crashing). Constraints: If the browser renderer is also unavailable, callers
-// must return domain.ErrUnsupportedMediaFile to skip the job without crashing.
+// Scope: Only feDisplacementMap is hard-blocked here because it is the confirmed crash trigger
+// (linebender/resvg issues #1007, #1019, #1021). feTurbulence and feComposite may appear in
+// combination with feDisplacementMap but do not cause SIGABRT on their own — they are handled
+// as browser-preferred but resvg-safe in requiresBrowserRendering. Over-blocking standalone
+// feTurbulence or feComposite would silently skip valid SVGs when no browser is available.
+//
+// Trade-offs: String matching is conservative but deliberately narrow — routing only confirmed
+// crash-inducing constructs away from resvg. Constraints: If the browser renderer is also
+// unavailable, callers must return domain.ErrUnsupportedMediaFile to skip the job without crashing.
 func willCrashResvg(svgData []byte) (bool, []string) {
 	content := string(svgData)
 	var reasons []string
 
-	// feDisplacementMap triggers a Rust assertion failure in resvg when buffer dimensions
-	// don't match after compositing — a known resvg bug on certain SVG inputs.
+	// feDisplacementMap triggers a Rust assertion failure in resvg when intermediate buffer
+	// dimensions don't match — a confirmed resvg bug (linebender/resvg#1007, #1019, #1021).
+	// This is the only primitive reliably confirmed to SIGABRT the process.
 	if strings.Contains(content, "feDisplacementMap") {
 		reasons = append(reasons, "feDisplacementMap")
-	}
-
-	// feComposite can produce mismatched buffer dimensions when composed with certain filter chains.
-	if strings.Contains(content, "feComposite") {
-		reasons = append(reasons, "feComposite")
-	}
-
-	// feTurbulence → feDisplacementMap is the most common crash-inducing pattern on production.
-	// Detect feTurbulence independently so that combination is caught even if feDisplacementMap
-	// check above ever becomes more targeted.
-	if strings.Contains(content, "feTurbulence") {
-		reasons = append(reasons, "feTurbulence")
 	}
 
 	return len(reasons) > 0, reasons
@@ -187,6 +182,17 @@ func (r *rasterizer) requiresBrowserRendering(svgData []byte) (bool, []string) {
 		strings.Contains(content, "<animateMotion") ||
 		strings.Contains(content, "<set") {
 		reasons = append(reasons, "smil-animation")
+	}
+
+	// feTurbulence and feComposite are handled by resvg without crashing, but produce degraded
+	// or incorrect output for complex filter chains (resvg#268, #760). Prefer the browser when
+	// available so generative/noise-based artworks render accurately. resvg is used as fallback.
+	// Note: feDisplacementMap is handled in willCrashResvg (process-fatal, not just degraded).
+	if strings.Contains(content, "feTurbulence") {
+		reasons = append(reasons, "feTurbulence")
+	}
+	if strings.Contains(content, "feComposite") {
+		reasons = append(reasons, "feComposite")
 	}
 
 	return len(reasons) > 0, reasons

--- a/internal/media/rasterizer/rasterizer.go
+++ b/internal/media/rasterizer/rasterizer.go
@@ -84,18 +84,14 @@ func (r *rasterizer) Rasterize(ctx context.Context, svgData []byte) ([]byte, err
 
 	// Check for SVG features that will crash resvg at the OS level (SIGABRT via CGO).
 	// These cannot be handled by resvg under any circumstance.
-	if crash, reasons := willCrashResvg(svgData); crash {
-		logger.WarnCtx(ctx, "SVG contains filter primitives that crash resvg; must use browser renderer",
-			zap.Strings("reasons", reasons),
-		)
+	if willCrashResvg(svgData) {
+		logger.WarnCtx(ctx, "SVG contains feDisplacementMap which crashes resvg; routing to browser renderer")
 		if r.enableBrowser && r.browserRasterizer != nil {
 			return r.rasterizeWithBrowser(ctx, svgData)
 		}
 		// Browser not available: return a skippable error so the job is marked failed
 		// rather than crashing the process and looping forever via SweepOrphanedJobs.
-		logger.WarnCtx(ctx, "Browser renderer unavailable for crash-inducing SVG; skipping",
-			zap.Strings("reasons", reasons),
-		)
+		logger.WarnCtx(ctx, "Browser renderer unavailable for crash-inducing SVG; skipping")
 		return nil, ErrUnsupportedSVGFilter
 	}
 
@@ -117,39 +113,17 @@ func (r *rasterizer) Rasterize(ctx context.Context, svgData []byte) ([]byte, err
 	return r.rasterizeWithResvg(ctx, svgData)
 }
 
-// willCrashResvg reports whether the SVG contains filter primitives confirmed to trigger a fatal
-// Rust assertion in resvg (SIGABRT). These SVGs must never reach resvg.Render because an OS
-// abort cannot be caught by Go's recover() — it terminates the entire process.
+// willCrashResvg reports whether the SVG contains feDisplacementMap, the only filter primitive
+// confirmed to trigger a fatal Rust assertion in resvg (SIGABRT via CGO). Such SVGs must never
+// reach resvg.Render because an OS abort cannot be caught by Go's recover().
 //
-// Reason: resvg's feDisplacementMap implementation asserts that the source, map, and destination
-// buffers share the same width. Certain SVGs violate this assumption and trigger the assertion:
-//
-//	assertion failed: src.width == map.width && src.width == dest.width
-//	note: run with RUST_BACKTRACE=1 ...
-//	fatal runtime error: failed to initiate panic, error 5
-//	SIGABRT: abort
-//
-// Scope: Only feDisplacementMap is hard-blocked here because it is the confirmed crash trigger
-// (linebender/resvg issues #1007, #1019, #1021). feTurbulence and feComposite may appear in
-// combination with feDisplacementMap but do not cause SIGABRT on their own — they are handled
-// as browser-preferred but resvg-safe in requiresBrowserRendering. Over-blocking standalone
-// feTurbulence or feComposite would silently skip valid SVGs when no browser is available.
-//
-// Trade-offs: String matching is conservative but deliberately narrow — routing only confirmed
-// crash-inducing constructs away from resvg. Constraints: If the browser renderer is also
-// unavailable, callers must return domain.ErrUnsupportedMediaFile to skip the job without crashing.
-func willCrashResvg(svgData []byte) (bool, []string) {
-	content := string(svgData)
-	var reasons []string
-
-	// feDisplacementMap triggers a Rust assertion failure in resvg when intermediate buffer
-	// dimensions don't match — a confirmed resvg bug (linebender/resvg#1007, #1019, #1021).
-	// This is the only primitive reliably confirmed to SIGABRT the process.
-	if strings.Contains(content, "feDisplacementMap") {
-		reasons = append(reasons, "feDisplacementMap")
-	}
-
-	return len(reasons) > 0, reasons
+// feDisplacementMap asserts that source, map, and dest buffers share the same width; certain
+// SVG inputs violate this and cause: "assertion failed: src.width == map.width" → SIGABRT.
+// See linebender/resvg#1007, #1019, #1021. feTurbulence and feComposite are handled separately
+// in requiresBrowserRendering — they degrade without crashing, so hard-blocking them would
+// silently skip valid SVGs when no browser is available.
+func willCrashResvg(svgData []byte) bool {
+	return strings.Contains(string(svgData), "feDisplacementMap")
 }
 
 // requiresBrowserRendering analyzes SVG content to determine if browser rendering is preferred.

--- a/internal/media/rasterizer/rasterizer.go
+++ b/internal/media/rasterizer/rasterizer.go
@@ -5,6 +5,7 @@ package rasterizer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,6 +14,12 @@ import (
 	"github.com/feral-file/ff-indexer-v2/internal/adapter"
 	"github.com/feral-file/ff-indexer-v2/internal/logger"
 )
+
+// ErrUnsupportedSVGFilter is returned when an SVG contains filter primitives that would crash
+// resvg (SIGABRT via CGO) and no browser renderer is available to handle it safely. Callers
+// should treat this as a skippable condition — the job is marked failed rather than retried
+// indefinitely, which would otherwise loop via SweepOrphanedJobs after each process crash.
+var ErrUnsupportedSVGFilter = errors.New("SVG contains filter primitives unsupported by resvg (no browser renderer available)")
 
 // Rasterizer handles SVG to PNG conversion using resvg or browser fallback
 //
@@ -60,40 +67,99 @@ func NewRasterizer(
 	}
 }
 
-// Rasterize converts SVG data to PNG format
+// Rasterize converts SVG data to PNG format.
+//
+// Routing priority:
+//  1. willCrashResvg — SVG features that cause SIGABRT in resvg (e.g. feDisplacementMap).
+//     These MUST use the browser renderer. If the browser is unavailable, return
+//     ErrUnsupportedSVGFilter so the caller can skip the job safely instead of crashing the process.
+//  2. requiresBrowserRendering — SVG features resvg cannot render faithfully but that will not
+//     crash (e.g. <foreignObject>, SMIL animations). Prefer browser; fall back to resvg if needed.
+//  3. Standard SVGs — use the fast resvg path.
 func (r *rasterizer) Rasterize(ctx context.Context, svgData []byte) ([]byte, error) {
 	logger.InfoCtx(ctx, "Starting SVG rasterization to PNG",
 		zap.Int("svgSize", len(svgData)),
 		zap.Int("targetWidth", r.width),
 	)
 
-	// Detect if SVG requires browser rendering
-	needsBrowser, reasons := r.requiresBrowserRendering(svgData)
-
-	if needsBrowser {
-		logger.InfoCtx(ctx, "SVG requires browser rendering",
+	// Check for SVG features that will crash resvg at the OS level (SIGABRT via CGO).
+	// These cannot be handled by resvg under any circumstance.
+	if crash, reasons := willCrashResvg(svgData); crash {
+		logger.WarnCtx(ctx, "SVG contains filter primitives that crash resvg; must use browser renderer",
 			zap.Strings("reasons", reasons),
 		)
-
-		if !r.enableBrowser {
-			logger.WarnCtx(ctx, "Browser rendering required but disabled, falling back to resvg")
-			return r.rasterizeWithResvg(ctx, svgData)
+		if r.enableBrowser && r.browserRasterizer != nil {
+			return r.rasterizeWithBrowser(ctx, svgData)
 		}
-
-		if r.browserRasterizer == nil {
-			logger.WarnCtx(ctx, "Browser rasterizer not configured, falling back to resvg")
-			return r.rasterizeWithResvg(ctx, svgData)
-		}
-
-		return r.rasterizeWithBrowser(ctx, svgData)
+		// Browser not available: return a skippable error so the job is marked failed
+		// rather than crashing the process and looping forever via SweepOrphanedJobs.
+		logger.WarnCtx(ctx, "Browser renderer unavailable for crash-inducing SVG; skipping",
+			zap.Strings("reasons", reasons),
+		)
+		return nil, ErrUnsupportedSVGFilter
 	}
 
-	// Use fast path (resvg) for standard SVGs
+	// Check for SVG features that resvg cannot render faithfully (degraded but not crashing).
+	if needsBrowser, reasons := r.requiresBrowserRendering(svgData); needsBrowser {
+		logger.InfoCtx(ctx, "SVG prefers browser rendering",
+			zap.Strings("reasons", reasons),
+		)
+		if r.enableBrowser && r.browserRasterizer != nil {
+			return r.rasterizeWithBrowser(ctx, svgData)
+		}
+		logger.WarnCtx(ctx, "Browser rendering preferred but unavailable, falling back to resvg",
+			zap.Strings("reasons", reasons),
+		)
+	}
+
+	// Standard SVG: use the fast resvg path.
 	logger.InfoCtx(ctx, "Using resvg for standard SVG")
 	return r.rasterizeWithResvg(ctx, svgData)
 }
 
-// requiresBrowserRendering analyzes SVG content to determine if browser rendering is needed
+// willCrashResvg reports whether the SVG contains filter primitives known to trigger a fatal
+// Rust assertion in resvg (SIGABRT). These SVGs must never reach resvg.Render because an OS
+// abort cannot be caught by Go's recover() — it terminates the entire process.
+//
+// Reason: resvg's feDisplacementMap implementation asserts that the source, map, and destination
+// buffers share the same width. Certain SVGs violate this assumption and trigger the assertion:
+//
+//	assertion failed: src.width == map.width && src.width == dest.width
+//	note: run with RUST_BACKTRACE=1 ...
+//	fatal runtime error: failed to initiate panic, error 5
+//	SIGABRT: abort
+//
+// Trade-offs: String matching is conservative (false-positive safe — over-routing to the browser
+// is better than crashing). Constraints: If the browser renderer is also unavailable, callers
+// must return domain.ErrUnsupportedMediaFile to skip the job without crashing.
+func willCrashResvg(svgData []byte) (bool, []string) {
+	content := string(svgData)
+	var reasons []string
+
+	// feDisplacementMap triggers a Rust assertion failure in resvg when buffer dimensions
+	// don't match after compositing — a known resvg bug on certain SVG inputs.
+	if strings.Contains(content, "feDisplacementMap") {
+		reasons = append(reasons, "feDisplacementMap")
+	}
+
+	// feComposite can produce mismatched buffer dimensions when composed with certain filter chains.
+	if strings.Contains(content, "feComposite") {
+		reasons = append(reasons, "feComposite")
+	}
+
+	// feTurbulence → feDisplacementMap is the most common crash-inducing pattern on production.
+	// Detect feTurbulence independently so that combination is caught even if feDisplacementMap
+	// check above ever becomes more targeted.
+	if strings.Contains(content, "feTurbulence") {
+		reasons = append(reasons, "feTurbulence")
+	}
+
+	return len(reasons) > 0, reasons
+}
+
+// requiresBrowserRendering analyzes SVG content to determine if browser rendering is preferred.
+// These are features resvg cannot render faithfully but where falling back to resvg still
+// produces a non-crashing (if degraded) result. For features that cause SIGABRT, see willCrashResvg.
 func (r *rasterizer) requiresBrowserRendering(svgData []byte) (bool, []string) {
 	content := string(svgData)
 	var reasons []string

--- a/internal/media/rasterizer/rasterizer_test.go
+++ b/internal/media/rasterizer/rasterizer_test.go
@@ -165,6 +165,101 @@ func TestRasterize_EncodingError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to encode PNG")
 }
 
+// TestRasterize_FeDisplacementMap_NoBrowser verifies that SVGs containing feDisplacementMap
+// (which crash resvg via SIGABRT) return ErrUnsupportedSVGFilter when no browser is available,
+// instead of calling resvg.Render and aborting the process.
+func TestRasterize_FeDisplacementMap_NoBrowser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockResvg := mocks.NewMockResvgClient(ctrl)
+	mockEncoder := mocks.NewMockImageEncoder(ctrl)
+	// resvg.Render must NEVER be called for crash-inducing SVGs.
+	mockResvg.EXPECT().Render(gomock.Any(), gomock.Any()).Times(0)
+
+	crashSVGs := []struct {
+		name string
+		svg  string
+	}{
+		{
+			name: "feDisplacementMap",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feDisplacementMap in="SourceGraphic" scale="10"/></filter></svg>`,
+		},
+		{
+			name: "feTurbulence",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feTurbulence type="fractalNoise" baseFrequency="0.9"/></filter></svg>`,
+		},
+		{
+			name: "feComposite",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feComposite in="SourceGraphic" in2="BackgroundImage" operator="over"/></filter></svg>`,
+		},
+		{
+			name: "feDisplacementMap+feTurbulence combination",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feTurbulence type="fractalNoise" baseFrequency="0.9"/><feDisplacementMap in="SourceGraphic" scale="10"/></filter></svg>`,
+		},
+	}
+
+	for _, tc := range crashSVGs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Browser disabled: enableBrowser=false, browserRasterizer=nil.
+			r := rasterizer.NewRasterizer(mockResvg, mockEncoder, nil, nil)
+			_, err := r.Rasterize(context.Background(), []byte(tc.svg))
+			require.ErrorIs(t, err, rasterizer.ErrUnsupportedSVGFilter,
+				"must return ErrUnsupportedSVGFilter, not call resvg.Render which would SIGABRT")
+		})
+	}
+}
+
+// TestRasterize_FeDisplacementMap_WithBrowser verifies that crash-inducing SVGs are forwarded
+// to the browser renderer when one is available, and never sent to resvg.
+func TestRasterize_FeDisplacementMap_WithBrowser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockResvg := mocks.NewMockResvgClient(ctrl)
+	mockEncoder := mocks.NewMockImageEncoder(ctrl)
+	mockBrowser := mocks.NewMockBrowserRasterizer(ctrl)
+
+	// resvg.Render must NEVER be called.
+	mockResvg.EXPECT().Render(gomock.Any(), gomock.Any()).Times(0)
+
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feDisplacementMap in="SourceGraphic" scale="10"/></filter></svg>`)
+	expectedPNG := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	mockBrowser.EXPECT().
+		RasterizeSVG(gomock.Any(), svg, 0).
+		Return(expectedPNG, nil)
+
+	r := rasterizer.NewRasterizer(mockResvg, mockEncoder, mockBrowser, &rasterizer.Config{EnableBrowserFallback: true})
+	result, err := r.Rasterize(context.Background(), svg)
+	require.NoError(t, err)
+	require.Equal(t, expectedPNG, result)
+}
+
+// TestRasterize_StandardSVG_UsesResvg confirms that a plain SVG (no crash-inducing features,
+// no browser-preference features) still takes the fast resvg path.
+func TestRasterize_StandardSVG_UsesResvg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockResvg := mocks.NewMockResvgClient(ctrl)
+	mockEncoder := mocks.NewMockImageEncoder(ctrl)
+	testImg := createTestImage()
+
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" fill="red"/></svg>`)
+
+	mockResvg.EXPECT().Render(svg, 0).Return(testImg, nil)
+	mockEncoder.EXPECT().EncodePNG(gomock.Any(), testImg).DoAndReturn(func(w *bytes.Buffer, img image.Image) error {
+		w.Write([]byte{0x89, 0x50, 0x4E, 0x47})
+		return nil
+	})
+
+	r := rasterizer.NewRasterizer(mockResvg, mockEncoder, nil, nil)
+	result, err := r.Rasterize(context.Background(), svg)
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+}
+
 func TestRasterize_WithCustomConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/media/rasterizer/rasterizer_test.go
+++ b/internal/media/rasterizer/rasterizer_test.go
@@ -166,15 +166,17 @@ func TestRasterize_EncodingError(t *testing.T) {
 }
 
 // TestRasterize_FeDisplacementMap_NoBrowser verifies that SVGs containing feDisplacementMap
-// (which crash resvg via SIGABRT) return ErrUnsupportedSVGFilter when no browser is available,
-// instead of calling resvg.Render and aborting the process.
+// (the only confirmed SIGABRT trigger in resvg) return ErrUnsupportedSVGFilter when no browser
+// is available, instead of calling resvg.Render and aborting the process.
+// Note: feTurbulence and feComposite alone are not hard-blocked — they go through browser-preferred
+// routing but fall back to resvg if no browser is available (non-fatal degraded output).
 func TestRasterize_FeDisplacementMap_NoBrowser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockResvg := mocks.NewMockResvgClient(ctrl)
 	mockEncoder := mocks.NewMockImageEncoder(ctrl)
-	// resvg.Render must NEVER be called for crash-inducing SVGs.
+	// resvg.Render must NEVER be called for SVGs containing feDisplacementMap.
 	mockResvg.EXPECT().Render(gomock.Any(), gomock.Any()).Times(0)
 
 	crashSVGs := []struct {
@@ -182,16 +184,8 @@ func TestRasterize_FeDisplacementMap_NoBrowser(t *testing.T) {
 		svg  string
 	}{
 		{
-			name: "feDisplacementMap",
+			name: "feDisplacementMap alone",
 			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feDisplacementMap in="SourceGraphic" scale="10"/></filter></svg>`,
-		},
-		{
-			name: "feTurbulence",
-			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feTurbulence type="fractalNoise" baseFrequency="0.9"/></filter></svg>`,
-		},
-		{
-			name: "feComposite",
-			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feComposite in="SourceGraphic" in2="BackgroundImage" operator="over"/></filter></svg>`,
 		},
 		{
 			name: "feDisplacementMap+feTurbulence combination",
@@ -206,6 +200,49 @@ func TestRasterize_FeDisplacementMap_NoBrowser(t *testing.T) {
 			_, err := r.Rasterize(context.Background(), []byte(tc.svg))
 			require.ErrorIs(t, err, rasterizer.ErrUnsupportedSVGFilter,
 				"must return ErrUnsupportedSVGFilter, not call resvg.Render which would SIGABRT")
+		})
+	}
+}
+
+// TestRasterize_FeTurbulenceFeComposite_FallsBackToResvg verifies that SVGs containing
+// feTurbulence or feComposite (without feDisplacementMap) are NOT hard-blocked — they attempt
+// browser rendering first, then fall back to resvg when no browser is available. This avoids
+// silently skipping valid SVGs that happen to use those filter primitives without hitting the
+// confirmed crash path.
+func TestRasterize_FeTurbulenceFeComposite_FallsBackToResvg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockResvg := mocks.NewMockResvgClient(ctrl)
+	mockEncoder := mocks.NewMockImageEncoder(ctrl)
+	testImg := createTestImage()
+
+	browserPreferredSVGs := []struct {
+		name string
+		svg  string
+	}{
+		{
+			name: "feTurbulence alone",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feTurbulence type="fractalNoise" baseFrequency="0.9"/></filter></svg>`,
+		},
+		{
+			name: "feComposite alone",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><filter id="f"><feComposite in="SourceGraphic" in2="BackgroundImage" operator="over"/></filter></svg>`,
+		},
+	}
+
+	for _, tc := range browserPreferredSVGs {
+		t.Run(tc.name, func(t *testing.T) {
+			svgBytes := []byte(tc.svg)
+			// No browser available: resvg.Render IS called as fallback (degraded but not fatal).
+			mockResvg.EXPECT().Render(svgBytes, 0).Return(testImg, nil)
+			mockEncoder.EXPECT().EncodePNG(gomock.Any(), testImg).DoAndReturn(func(w *bytes.Buffer, img image.Image) error {
+				w.Write([]byte{0x89, 0x50, 0x4E, 0x47})
+				return nil
+			})
+			r := rasterizer.NewRasterizer(mockResvg, mockEncoder, nil, nil)
+			_, err := r.Rasterize(context.Background(), svgBytes)
+			require.NoError(t, err, "feTurbulence/feComposite alone must not return ErrUnsupportedSVGFilter")
 		})
 	}
 }

--- a/internal/media/rasterizer/rasterizer_test.go
+++ b/internal/media/rasterizer/rasterizer_test.go
@@ -204,6 +204,48 @@ func TestRasterize_FeDisplacementMap_NoBrowser(t *testing.T) {
 	}
 }
 
+// TestRasterize_FeDisplacementMap_MentionedButNotUsed verifies that the crash guard is
+// XML-aware: the string "feDisplacementMap" appearing only in a comment or <desc> text node
+// does NOT block the SVG — resvg is called normally because no actual element is present.
+// Regression for the original strings.Contains over-blocking that would fail valid SVGs.
+func TestRasterize_FeDisplacementMap_MentionedButNotUsed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockResvg := mocks.NewMockResvgClient(ctrl)
+	mockEncoder := mocks.NewMockImageEncoder(ctrl)
+	testImg := createTestImage()
+
+	safeSVGs := []struct {
+		name string
+		svg  string
+	}{
+		{
+			name: "feDisplacementMap in XML comment only",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><!-- feDisplacementMap technique --><rect width="10" height="10" fill="red"/></svg>`,
+		},
+		{
+			name: "feDisplacementMap in desc element only",
+			svg:  `<svg xmlns="http://www.w3.org/2000/svg"><desc>Uses feDisplacementMap approach</desc><rect width="10" height="10" fill="blue"/></svg>`,
+		},
+	}
+
+	for _, tc := range safeSVGs {
+		t.Run(tc.name, func(t *testing.T) {
+			svgBytes := []byte(tc.svg)
+			// resvg MUST be called — text mention of feDisplacementMap is not a crash risk.
+			mockResvg.EXPECT().Render(svgBytes, 0).Return(testImg, nil)
+			mockEncoder.EXPECT().EncodePNG(gomock.Any(), testImg).DoAndReturn(func(w *bytes.Buffer, img image.Image) error {
+				w.Write([]byte{0x89, 0x50, 0x4E, 0x47})
+				return nil
+			})
+			r := rasterizer.NewRasterizer(mockResvg, mockEncoder, nil, nil)
+			_, err := r.Rasterize(context.Background(), svgBytes)
+			require.NoError(t, err, "feDisplacementMap text mention must not block resvg")
+		})
+	}
+}
+
 // TestRasterize_FeTurbulenceFeComposite_FallsBackToResvg verifies that SVGs containing
 // feTurbulence or feComposite (without feDisplacementMap) are NOT hard-blocked — they attempt
 // browser rendering first, then fall back to resvg when no browser is available. This avoids

--- a/internal/mocks/store.go
+++ b/internal/mocks/store.go
@@ -1000,18 +1000,19 @@ func (mr *MockStoreMockRecorder) SweepCanceledPendingJobs(ctx, queue any) *gomoc
 }
 
 // SweepOrphanedJobs mocks base method.
-func (m *MockStore) SweepOrphanedJobs(ctx context.Context, queue string) (int64, error) {
+func (m *MockStore) SweepOrphanedJobs(ctx context.Context, queue string, maxAttempts int) (int64, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SweepOrphanedJobs", ctx, queue)
+	ret := m.ctrl.Call(m, "SweepOrphanedJobs", ctx, queue, maxAttempts)
 	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // SweepOrphanedJobs indicates an expected call of SweepOrphanedJobs.
-func (mr *MockStoreMockRecorder) SweepOrphanedJobs(ctx, queue any) *gomock.Call {
+func (mr *MockStoreMockRecorder) SweepOrphanedJobs(ctx, queue, maxAttempts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepOrphanedJobs", reflect.TypeOf((*MockStore)(nil).SweepOrphanedJobs), ctx, queue)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepOrphanedJobs", reflect.TypeOf((*MockStore)(nil).SweepOrphanedJobs), ctx, queue, maxAttempts)
 }
 
 // UpdateAddressIndexingJobProgress mocks base method.

--- a/internal/providers/jobs/worker.go
+++ b/internal/providers/jobs/worker.go
@@ -180,20 +180,35 @@ func (w *Worker) ctxErr(ctx context.Context) error {
 	return nil
 }
 
-// claimAndDispatch claims jobs up to batch size and dispatches them to w.pool (created in Run).
-// The pool ensures the running job count never exceeds Concurrency.
+// claimAndDispatch claims only as many jobs as the pool can immediately absorb and dispatches
+// them to w.pool (created in Run).
 //
-// Reason: Using pond.Pool provides consistent goroutine management across the codebase and
-// automatic handling of worker lifecycle. Jobs run asynchronously, with the pool tracking
-// completion and the fatalErr channel enabling fail-fast on terminal state persistence failures.
+// Reason: ClaimJobs marks rows running in the DB immediately upon claim. Without backpressure,
+// every poll tick could claim up to BatchSize rows and mark them all running, while only
+// Concurrency handlers actually execute — inflating the observable running count in the DB far
+// beyond the configured limit. Gating claim size on pool availability (RunningWorkers +
+// WaitingTasks) keeps DB running rows ≈ actual executing goroutines.
+//
+// Trade-offs: BatchSize still sets the pond queue buffer (WithQueueSize) as a safety valve for
+// burst, but it no longer drives how many jobs are claimed per tick. Poll latency (PollInterval)
+// bounds how quickly new work is picked up after capacity opens.
 func (w *Worker) claimAndDispatch(ctx context.Context, fatalErr chan<- error) error {
 	if err := w.ctxErr(ctx); err != nil {
 		return err
 	}
 
-	// Claim jobs up to the batch size
-	// Pool will naturally limit concurrent execution to Concurrency
-	jobs, err := w.store.ClaimJobs(ctx, w.config.Queue, w.config.BatchSize)
+	// Only claim what the pool can absorb right now. RunningWorkers + WaitingTasks equals the
+	// number of already-claimed jobs that have not yet completed. Claiming more would mark
+	// additional rows running in the DB while they sit idle in the pond queue.
+	// WaitingTasks returns uint64 but is bounded by BatchSize (a small configured int),
+	// so the conversion to int cannot overflow in practice.
+	inUse := int(w.pool.RunningWorkers()) + int(w.pool.WaitingTasks()) //nolint:gosec // bounded by BatchSize
+	available := w.config.Concurrency - inUse
+	if available <= 0 {
+		return nil
+	}
+
+	jobs, err := w.store.ClaimJobs(ctx, w.config.Queue, available)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/jobs/worker.go
+++ b/internal/providers/jobs/worker.go
@@ -224,6 +224,11 @@ func (w *Worker) claimAndDispatch(ctx context.Context, fatalErr chan<- error) er
 	if available <= 0 {
 		return nil
 	}
+	// Also cap by BatchSize so the claim limit stays within the operator-configured batch bound
+	// regardless of concurrency setting (e.g. concurrency=50, batch_size=16 → claim at most 16).
+	if available > w.config.BatchSize {
+		available = w.config.BatchSize
+	}
 
 	jobs, err := w.store.ClaimJobs(ctx, w.config.Queue, available)
 	if err != nil {

--- a/internal/providers/jobs/worker.go
+++ b/internal/providers/jobs/worker.go
@@ -30,6 +30,12 @@ type WorkerConfig struct {
 	BatchSize int
 	// CancelInterval is how often to scan for in-flight jobs with cancel_requested and cancel ctx.
 	CancelInterval time.Duration
+	// MaxAttempts is the maximum number of times a job may be claimed before SweepOrphanedJobs
+	// permanently fails it instead of resetting it to pending. This breaks the crash loop caused
+	// by CGO/Rust SIGABRT panics (e.g. resvg feDisplacementMap): without a cap, a job that
+	// crashes the process is orphaned, swept back to pending, and re-executed indefinitely.
+	// Default: 3 (allows recovery from transient host pressure; terminates deterministic loops).
+	MaxAttempts int
 }
 
 // Worker runs a single-queue consumer: advisory lock, startup sweep, poll loop, and cancel
@@ -74,6 +80,9 @@ func NewWorker(st store.Store, reg *Registry, cfg WorkerConfig) *Worker {
 	if cfg.CancelInterval <= 0 {
 		cfg.CancelInterval = 5 * time.Second
 	}
+	if cfg.MaxAttempts < 1 {
+		cfg.MaxAttempts = 3
+	}
 	return &Worker{
 		store:    st,
 		registry: reg,
@@ -107,8 +116,16 @@ func (w *Worker) Run(ctx context.Context) error {
 	}
 	defer release()
 
-	if _, err := w.store.SweepOrphanedJobs(ctx, w.config.Queue); err != nil {
+	reset, failed, err := w.store.SweepOrphanedJobs(ctx, w.config.Queue, w.config.MaxAttempts)
+	if err != nil {
 		return err
+	}
+	if reset > 0 || failed > 0 {
+		logger.InfoCtx(ctx, "swept orphaned jobs on startup",
+			zap.Int64("reset_to_pending", reset),
+			zap.Int64("failed_crash_loop", failed),
+			zap.Int("max_attempts", w.config.MaxAttempts),
+		)
 	}
 
 	// Create worker pool with context

--- a/internal/providers/jobs/worker_test.go
+++ b/internal/providers/jobs/worker_test.go
@@ -3,6 +3,7 @@ package jobs_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -567,26 +568,27 @@ func TestWorker_Run_RespectsConcurrencyWhenClaiming(t *testing.T) {
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "q").Return(true, func() {}, nil)
 	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q").Return(int64(0), nil)
 
-	// With pond, we claim up to BatchSize, and pond queues internally
+	// With backpressure, ClaimJobs is called with the number of available pool slots, not BatchSize.
+	// Return exactly `limit` jobs per call so the pool fills to Concurrency correctly.
 	var claimCallCount atomic.Int32
-	st.EXPECT().ClaimJobs(gomock.Any(), "q", 10).AnyTimes().DoAndReturn(
+	st.EXPECT().ClaimJobs(gomock.Any(), "q", gomock.Any()).AnyTimes().DoAndReturn(
 		func(_ context.Context, _ string, limit int) ([]*schema.Job, error) {
 			callNum := claimCallCount.Add(1)
 
-			// First 2 calls: return jobs
+			// First 2 calls: return exactly limit jobs (backpressure keeps limit ≤ Concurrency).
 			if callNum <= 2 {
-				jobs := make([]*schema.Job, 0, 10)
-				for i := 0; i < 10; i++ {
-					jobs = append(jobs, &schema.Job{
+				result := make([]*schema.Job, limit)
+				for i := range result {
+					result[i] = &schema.Job{
 						ID:      int64(callNum)*100 + int64(i),
 						Kind:    "slow",
 						Queue:   "q",
 						Payload: []byte("[]"),
-					})
+					}
 				}
-				return jobs, nil
+				return result, nil
 			}
-			// After 2 calls, return nothing
+			// After 2 calls, return nothing.
 			return nil, nil
 		},
 	)
@@ -595,8 +597,8 @@ func TestWorker_Run_RespectsConcurrencyWhenClaiming(t *testing.T) {
 	st.EXPECT().ListInFlightJobsWithCancelRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	st.EXPECT().SweepCanceledPendingJobs(gomock.Any(), "q").Return(int64(0), nil).AnyTimes()
 
-	// Configure worker with Concurrency=2, BatchSize=10
-	// Pond will queue up to 10 jobs but only execute 2 concurrently
+	// BatchSize > Concurrency; backpressure ensures ClaimJobs is called with Concurrency (2),
+	// not BatchSize (10). The pool enforces that only 2 handlers run simultaneously.
 	w := jobs.NewWorker(st, reg, jobs.WorkerConfig{
 		Queue:          "q",
 		Concurrency:    2,
@@ -670,6 +672,94 @@ func TestWorker_Run_DoesNotClaimCanceledPendingJobs(t *testing.T) {
 
 	// Verify the handler was never executed
 	require.False(t, handlerCalled.Load(), "handler should not execute for canceled pending jobs")
+}
+
+// TestWorker_Run_ClaimBackpressure verifies that claimAndDispatch uses pool occupancy to gate
+// how many jobs it claims per tick, keeping DB running rows ≈ executing goroutines.
+// With Concurrency=2 and BatchSize=100, the first claim must request 2, not 100.
+// While both goroutines are occupied, no further claims must be made.
+func TestWorker_Run_ClaimBackpressure(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	st := mocks.NewMockStore(ctrl)
+	reg := jobs.NewRegistry(adapter.NewJSON())
+
+	// Jobs block until release is closed so we can observe pool state while it is full.
+	release := make(chan struct{})
+	allStarted := make(chan struct{})
+	var startCount atomic.Int32
+	reg.Register("slow", func(ctx context.Context) error {
+		if startCount.Add(1) == 2 {
+			close(allStarted)
+		}
+		<-release
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	var claimLimits []int // limits passed to ClaimJobs, in call order
+	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "q").Return(true, func() {}, nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q").Return(int64(0), nil)
+	st.EXPECT().ClaimJobs(gomock.Any(), "q", gomock.Any()).AnyTimes().DoAndReturn(
+		func(_ context.Context, _ string, limit int) ([]*schema.Job, error) {
+			mu.Lock()
+			claimLimits = append(claimLimits, limit)
+			isFirst := len(claimLimits) == 1
+			mu.Unlock()
+			if isFirst {
+				// Return exactly limit slow jobs to fill the pool.
+				result := make([]*schema.Job, limit)
+				for i := range result {
+					result[i] = &schema.Job{
+						ID:      int64(i + 1),
+						Kind:    "slow",
+						Queue:   "q",
+						Payload: []byte("[]"),
+					}
+				}
+				return result, nil
+			}
+			return nil, nil
+		},
+	)
+	st.EXPECT().MarkJobSucceeded(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	st.EXPECT().ListInFlightJobsWithCancelRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	w := jobs.NewWorker(st, reg, jobs.WorkerConfig{
+		Queue:          "q",
+		Concurrency:    2,
+		BatchSize:      100, // deliberately >> Concurrency; backpressure must prevent over-claiming
+		PollInterval:   20 * time.Millisecond,
+		CancelInterval: time.Hour,
+	})
+	errC := goRun(w, ctx)
+
+	// Wait for both slow jobs to start (pool now at capacity), then let several poll ticks fire.
+	<-allStarted
+	claimsWhileFull := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(claimLimits)
+	}
+	countBefore := claimsWhileFull()
+	time.Sleep(100 * time.Millisecond) // ~5 poll ticks while pool is at capacity
+
+	// ClaimJobs must not have been called again while the pool was full.
+	require.Equal(t, countBefore, claimsWhileFull(), "ClaimJobs must not be called while pool is at capacity")
+
+	// Release all slow jobs and let the worker drain cleanly.
+	close(release)
+	cancel()
+	require.NoError(t, <-errC)
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The first (and only pre-release) claim must use Concurrency (2), not BatchSize (100).
+	require.NotEmpty(t, claimLimits, "expected at least one ClaimJobs call")
+	require.Equal(t, 2, claimLimits[0], "first claim must be limited to Concurrency, not BatchSize")
 }
 
 func goRun(w *jobs.Worker, ctx context.Context) <-chan error {

--- a/internal/providers/jobs/worker_test.go
+++ b/internal/providers/jobs/worker_test.go
@@ -40,7 +40,7 @@ func TestWorker_Run_LockNotAcquired(t *testing.T) {
 	ctx := context.Background()
 	st.EXPECT().AcquireJobQueueLock(ctx, "tok").Return(false, func() {}, nil)
 	// Sweep must not run when the lock is not held.
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), gomock.Any()).Times(0)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	w := jobs.NewWorker(st, jobs.NewRegistry(adapter.NewJSON()), jobs.WorkerConfig{Queue: "tok"})
 	require.NoError(t, w.Run(ctx))
@@ -64,7 +64,7 @@ func TestWorker_Run_SweepError(t *testing.T) {
 	ctx := context.Background()
 	want := errors.New("sweep")
 	st.EXPECT().AcquireJobQueueLock(ctx, "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(ctx, "tok").Return(int64(0), want)
+	st.EXPECT().SweepOrphanedJobs(ctx, "tok", gomock.Any()).Return(int64(0), int64(0), want)
 	w := jobs.NewWorker(st, jobs.NewRegistry(adapter.NewJSON()), jobs.WorkerConfig{Queue: "tok"})
 	require.ErrorIs(t, w.Run(ctx), want)
 }
@@ -82,7 +82,7 @@ func TestWorker_Run_ClaimsJobAndMarksSucceeded(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -117,7 +117,7 @@ func TestWorker_Run_HandlerReschedules(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -151,7 +151,7 @@ func TestWorker_Run_HandlerFails(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -190,7 +190,7 @@ func TestWorker_Run_CancelObserverMarksCanceled(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -240,7 +240,7 @@ func TestWorker_Run_OnShutdownReschedules(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -276,7 +276,7 @@ func TestWorker_Run_MarkJobSucceededFails_WorkerExits(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -309,7 +309,7 @@ func TestWorker_Run_MarkJobFailedFails_WorkerExits(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -343,7 +343,7 @@ func TestWorker_Run_RescheduleJobFails_WorkerExits(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -381,7 +381,7 @@ func TestWorker_Run_ShutdownRescheduleFails_WorkerExits(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -435,7 +435,7 @@ func TestWorker_Run_FatalErrorCancelsBlockingHandlers(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -502,7 +502,7 @@ func TestWorker_Run_MarkJobCanceledFails_WorkerExits(t *testing.T) {
 
 	var claimCalls int32
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "tok").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "tok", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "tok", gomock.Any()).AnyTimes().DoAndReturn(
 		func(context.Context, string, int) ([]*schema.Job, error) {
 			if atomic.AddInt32(&claimCalls, 1) == 1 {
@@ -566,7 +566,7 @@ func TestWorker_Run_RespectsConcurrencyWhenClaiming(t *testing.T) {
 	defer cancel()
 
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "q").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q", gomock.Any()).Return(int64(0), int64(0), nil)
 
 	// With backpressure, ClaimJobs is called with the number of available pool slots, not BatchSize.
 	// Return exactly `limit` jobs per call so the pool fills to Concurrency correctly.
@@ -641,7 +641,7 @@ func TestWorker_Run_DoesNotClaimCanceledPendingJobs(t *testing.T) {
 	defer cancel()
 
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "q").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q", gomock.Any()).Return(int64(0), int64(0), nil)
 
 	// ClaimJobs should filter out canceled jobs (due to cancel_requested=false in SQL)
 	st.EXPECT().ClaimJobs(gomock.Any(), "q", gomock.Any()).AnyTimes().Return(nil, nil)
@@ -702,7 +702,7 @@ func TestWorker_Run_ClaimBackpressure(t *testing.T) {
 	var mu sync.Mutex
 	var claimLimits []int // limits passed to ClaimJobs, in call order
 	st.EXPECT().AcquireJobQueueLock(gomock.Any(), "q").Return(true, func() {}, nil)
-	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q").Return(int64(0), nil)
+	st.EXPECT().SweepOrphanedJobs(gomock.Any(), "q", gomock.Any()).Return(int64(0), int64(0), nil)
 	st.EXPECT().ClaimJobs(gomock.Any(), "q", gomock.Any()).AnyTimes().DoAndReturn(
 		func(_ context.Context, _ string, limit int) ([]*schema.Job, error) {
 			mu.Lock()

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -3426,16 +3426,23 @@ func (s *pgStore) MarkJobFailed(ctx context.Context, id int64, lastErr string) e
 }
 
 // RescheduleJob moves a running job back to pending with a new run_after.
+//
+// Reason: attempt_count is reset to 0 here because a clean reschedule (e.g. quota exhaustion via
+// jobs.ErrReschedule) represents a deliberate handler decision, not a crash. Without the reset,
+// repeated quota-triggered reschedules would accumulate attempt_count and cause SweepOrphanedJobs
+// to permanently fail a healthy job after maxAttempts cycles — defeating the crash-loop cap which
+// is intended only for jobs that killed the process (SIGABRT/OOM).
 func (s *pgStore) RescheduleJob(ctx context.Context, id int64, runAfter time.Time) error {
 	runAfter = runAfter.UTC()
 	now := time.Now().UTC()
 	result := s.db.WithContext(ctx).Model(&schema.Job{}).
 		Where("id = ? AND status = ?", id, schema.JobStatusRunning).
 		Updates(map[string]any{
-			"status":     schema.JobStatusPending,
-			"run_after":  runAfter,
-			"started_at": gorm.Expr("NULL"),
-			"updated_at": now,
+			"status":        schema.JobStatusPending,
+			"run_after":     runAfter,
+			"started_at":    gorm.Expr("NULL"),
+			"attempt_count": 0,
+			"updated_at":    now,
 		})
 	if result.Error != nil {
 		return result.Error

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -3341,8 +3341,13 @@ func (s *pgStore) GetJob(ctx context.Context, id int64) (*schema.Job, error) {
 	return &j, nil
 }
 
-// ClaimJobs claims pending, due jobs and marks them running.
+// ClaimJobs claims pending, due jobs, marks them running, and increments attempt_count.
 // Jobs with cancel_requested=true are excluded to prevent executing user-canceled work.
+//
+// Reason: Incrementing attempt_count atomically in the claim UPDATE (not in a separate query)
+// ensures the count is accurate even when the process crashes mid-execution. SweepOrphanedJobs
+// reads attempt_count to decide whether to reset a crashed job to pending or permanently fail it,
+// breaking the restart → orphan → sweep → pending → crash loop caused by CGO/Rust SIGABRT panics.
 func (s *pgStore) ClaimJobs(ctx context.Context, queue string, limit int) ([]*schema.Job, error) {
 	if limit <= 0 {
 		return nil, nil
@@ -3363,11 +3368,12 @@ WITH picked AS (
 UPDATE jobs
 SET
 	status = 'running',
+	attempt_count = attempt_count + 1,
 	started_at = ?,
 	updated_at = ?
 FROM picked
 WHERE jobs.id = picked.id
-RETURNING jobs.id, jobs.queue, jobs.kind, jobs.payload, jobs.status, jobs.unique_key, jobs.run_after, jobs.last_error, jobs.cancel_requested, jobs.created_at, jobs.updated_at, jobs.started_at, jobs.finished_at
+RETURNING jobs.id, jobs.queue, jobs.kind, jobs.payload, jobs.status, jobs.unique_key, jobs.run_after, jobs.last_error, jobs.cancel_requested, jobs.attempt_count, jobs.created_at, jobs.updated_at, jobs.started_at, jobs.finished_at
 `
 	var rows []schema.Job
 	if err := s.db.WithContext(ctx).Raw(claimSQL, queue, now, limit, now, now).Scan(&rows).Error; err != nil {
@@ -3477,20 +3483,53 @@ func (s *pgStore) MarkJobCanceled(ctx context.Context, id int64) error {
 	return nil
 }
 
-// SweepOrphanedJobs resets running jobs in a queue to pending (crash recovery).
-func (s *pgStore) SweepOrphanedJobs(ctx context.Context, queue string) (int64, error) {
+// SweepOrphanedJobs recovers running jobs left behind by a crashed worker process.
+//
+// Jobs whose attempt_count < maxAttempts are reset to pending so the worker can retry them.
+// Jobs whose attempt_count >= maxAttempts are permanently transitioned to failed with a
+// last_error message that records the crash-loop termination reason.
+//
+// Reason: Without the attempt cap, any job that crashes the process via SIGABRT (e.g. an SVG
+// with an feDisplacementMap filter that triggers a Rust assertion in resvg via CGO) would loop
+// forever: run → SIGABRT → orphan → sweep → pending → run → SIGABRT ...
+// The attempt cap makes the loop finite: after maxAttempts crashes the job is marked failed and
+// never re-queued, giving operators a permanent durable signal in jobs.last_error.
+//
+// Trade-offs: maxAttempts must be > 1 to allow transient-failure recovery (e.g. OOM killed by
+// the OS mid-job). A value of 3 is the recommended default: handles transient host pressure
+// while still breaking deterministic crash loops quickly.
+//
+// Returns (reset count, failed count, error).
+func (s *pgStore) SweepOrphanedJobs(ctx context.Context, queue string, maxAttempts int) (int64, int64, error) {
 	now := time.Now().UTC()
-	result := s.db.WithContext(ctx).Model(&schema.Job{}).
+
+	// Permanently fail jobs that have crashed maxAttempts or more times.
+	// These will never be retried, giving operators a clear terminal signal.
+	failedResult := s.db.WithContext(ctx).Model(&schema.Job{}).
+		Where("queue = ? AND status = ? AND attempt_count >= ?", queue, schema.JobStatusRunning, maxAttempts).
+		Updates(map[string]any{
+			"status":      schema.JobStatusFailed,
+			"last_error":  fmt.Sprintf("crash-loop terminated: job failed %d time(s) without completing (process crash or SIGABRT)", maxAttempts),
+			"finished_at": now,
+			"updated_at":  now,
+		})
+	if failedResult.Error != nil {
+		return 0, 0, failedResult.Error
+	}
+
+	// Reset remaining orphaned jobs (attempt_count < maxAttempts) back to pending for retry.
+	resetResult := s.db.WithContext(ctx).Model(&schema.Job{}).
 		Where("queue = ? AND status = ?", queue, schema.JobStatusRunning).
 		Updates(map[string]any{
 			"status":     schema.JobStatusPending,
 			"started_at": gorm.Expr("NULL"),
 			"updated_at": now,
 		})
-	if result.Error != nil {
-		return 0, result.Error
+	if resetResult.Error != nil {
+		return 0, failedResult.RowsAffected, resetResult.Error
 	}
-	return result.RowsAffected, nil
+
+	return resetResult.RowsAffected, failedResult.RowsAffected, nil
 }
 
 // SweepCanceledPendingJobs transitions pending jobs with cancel_requested to canceled status.

--- a/internal/store/schema/job.go
+++ b/internal/store/schema/job.go
@@ -42,6 +42,10 @@ type Job struct {
 	LastError *string `gorm:"column:last_error"`
 	// CancelRequested is set by RequestJobCancel; the worker stops the handler and moves to canceled when observed.
 	CancelRequested bool `gorm:"column:cancel_requested;not null;default:false"`
+	// AttemptCount is incremented by ClaimJobs each time the job is claimed. SweepOrphanedJobs
+	// uses this to permanently fail jobs that have crashed the process too many times, breaking
+	// the restart → orphan → sweep → pending → crash loop caused by CGO/Rust SIGABRT panics.
+	AttemptCount int `gorm:"column:attempt_count;not null;default:0"`
 	// CreatedAt is when the row was inserted.
 	CreatedAt time.Time `gorm:"column:created_at;not null;default:now()"`
 	// UpdatedAt is maintained by the updated_at trigger.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -531,14 +531,18 @@ type Store interface {
 	RequestJobCancel(ctx context.Context, id int64) error
 	// MarkJobCanceled sets status=canceled and finished_at when the handler observes cancelation.
 	MarkJobCanceled(ctx context.Context, id int64) error
-	// SweepOrphanedJobs returns running jobs in a queue to pending at worker startup (crash recovery) when no
-	// per-job heartbeat/lease is stored.
+	// SweepOrphanedJobs recovers running jobs left behind by a crashed worker.
+	// Jobs whose attempt_count < maxAttempts are reset to pending for retry.
+	// Jobs whose attempt_count >= maxAttempts are permanently failed with a crash-loop message
+	// in last_error — preventing an infinite restart → crash → orphan → pending → crash loop
+	// caused by CGO/Rust SIGABRT panics (e.g. resvg feDisplacementMap assertion failures).
 	//
 	// Reason: A running row without a live worker must not block the queue.
-	// Trade-offs: A slow shutdown can briefly duplicate work if a new worker starts before the old one exits, but
-	// v1 uses unique keys and idempotent flows where that matters; otherwise duplicate execution is a known ops edge.
-	// Constraints: Only rows with the given queue and status=running are updated. Returns the number of rows changed.
-	SweepOrphanedJobs(ctx context.Context, queue string) (int64, error)
+	// Trade-offs: A slow shutdown can briefly duplicate work if a new worker starts before the
+	// old one exits, but v1 uses unique keys and idempotent flows where that matters.
+	// Constraints: Only rows with the given queue and status=running are updated.
+	// Returns (reset count, failed count, error).
+	SweepOrphanedJobs(ctx context.Context, queue string, maxAttempts int) (reset int64, failed int64, err error)
 	// SweepCanceledPendingJobs transitions pending jobs with cancel_requested=true to canceled status.
 	// This ensures user cancellation intent is reflected in terminal job state, since ClaimJobs now filters
 	// out jobs with cancel_requested=true (preventing their execution).

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6495,19 +6495,53 @@ func testJobQueue(t *testing.T, store Store) {
 		assert.WithinDuration(t, next, after.RunAfter, time.Second)
 	})
 
-	t.Run("sweep returns orphaned running to pending", func(t *testing.T) {
+	t.Run("sweep returns orphaned running to pending when under max_attempts", func(t *testing.T) {
 		job, _, err := store.EnqueueJob(ctx, EnqueueJobInput{Queue: "q_sweep", Kind: "K", Payload: []byte(`{}`)})
 		require.NoError(t, err)
 		claimed, err := store.ClaimJobs(ctx, "q_sweep", 1)
 		require.NoError(t, err)
 		require.Len(t, claimed, 1)
 		assert.Equal(t, schema.JobStatusRunning, claimed[0].Status)
-		n, err := store.SweepOrphanedJobs(ctx, "q_sweep")
+		assert.Equal(t, 1, claimed[0].AttemptCount)
+		// maxAttempts=3: attempt_count=1 < 3, so job should be reset to pending.
+		reset, failed, err := store.SweepOrphanedJobs(ctx, "q_sweep", 3)
 		require.NoError(t, err)
-		assert.Equal(t, int64(1), n)
+		assert.Equal(t, int64(1), reset)
+		assert.Equal(t, int64(0), failed)
 		after, err := store.GetJob(ctx, job.ID)
 		require.NoError(t, err)
 		assert.Equal(t, schema.JobStatusPending, after.Status)
+	})
+
+	t.Run("sweep permanently fails orphaned job at max_attempts", func(t *testing.T) {
+		q := "q_sweep_maxattempts"
+		job, _, err := store.EnqueueJob(ctx, EnqueueJobInput{Queue: q, Kind: "K", Payload: []byte(`{}`)})
+		require.NoError(t, err)
+		// Claim the job maxAttempts times so attempt_count reaches the threshold.
+		const maxAttempts = 3
+		for i := range maxAttempts {
+			claimed, err := store.ClaimJobs(ctx, q, 1)
+			require.NoError(t, err)
+			if i < maxAttempts-1 {
+				// Reset back to pending for subsequent claims (simulates crash sweep).
+				reset, failed, err := store.SweepOrphanedJobs(ctx, q, maxAttempts)
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), reset)
+				assert.Equal(t, int64(0), failed)
+			} else {
+				// Last claim: attempt_count == maxAttempts — final sweep must fail the job.
+				assert.Equal(t, maxAttempts, claimed[0].AttemptCount)
+				reset, failed, err := store.SweepOrphanedJobs(ctx, q, maxAttempts)
+				require.NoError(t, err)
+				assert.Equal(t, int64(0), reset, "exhausted job must not be reset to pending")
+				assert.Equal(t, int64(1), failed, "exhausted job must be marked failed")
+			}
+		}
+		after, err := store.GetJob(ctx, job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, schema.JobStatusFailed, after.Status)
+		require.NotNil(t, after.LastError)
+		assert.Contains(t, *after.LastError, "crash-loop terminated")
 	})
 
 	t.Run("request cancel and list in-flight with cancel flag", func(t *testing.T) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6479,13 +6479,14 @@ func testJobQueue(t *testing.T, store Store) {
 		assert.Empty(t, claimed)
 	})
 
-	t.Run("reschedule running job to pending with new run_after", func(t *testing.T) {
+	t.Run("reschedule running job to pending with new run_after and resets attempt_count", func(t *testing.T) {
 		_, _, err := store.EnqueueJob(ctx, EnqueueJobInput{Queue: "q_rs", Kind: "K", Payload: []byte(`{}`)})
 		require.NoError(t, err)
 		claimed, err := store.ClaimJobs(ctx, "q_rs", 1)
 		require.NoError(t, err)
 		require.Len(t, claimed, 1)
 		assert.Equal(t, schema.JobStatusRunning, claimed[0].Status)
+		assert.Equal(t, 1, claimed[0].AttemptCount, "attempt_count should be 1 after claim")
 		next := time.Now().UTC().Add(5 * time.Minute)
 		require.NoError(t, store.RescheduleJob(ctx, claimed[0].ID, next))
 		after, err := store.GetJob(ctx, claimed[0].ID)
@@ -6493,6 +6494,9 @@ func testJobQueue(t *testing.T, store Store) {
 		assert.Equal(t, schema.JobStatusPending, after.Status)
 		assert.Nil(t, after.StartedAt)
 		assert.WithinDuration(t, next, after.RunAfter, time.Second)
+		// Regression: attempt_count must be reset to 0 on clean reschedule so that quota-triggered
+		// reschedules do not accumulate toward the crash-loop cap in SweepOrphanedJobs.
+		assert.Equal(t, 0, after.AttemptCount, "RescheduleJob must reset attempt_count to 0")
 	})
 
 	t.Run("sweep returns orphaned running to pending when under max_attempts", func(t *testing.T) {
@@ -6542,6 +6546,42 @@ func testJobQueue(t *testing.T, store Store) {
 		assert.Equal(t, schema.JobStatusFailed, after.Status)
 		require.NotNil(t, after.LastError)
 		assert.Contains(t, *after.LastError, "crash-loop terminated")
+	})
+
+	t.Run("sweep does not fail a job that only rescheduled cleanly past maxAttempts", func(t *testing.T) {
+		// Regression: attempt_count was not reset on RescheduleJob, so repeated quota-triggered
+		// reschedules could accumulate the counter and cause SweepOrphanedJobs to permanently
+		// fail a healthy job that was never in a crash loop.
+		q := "q_reschedule_no_fail"
+		job, _, err := store.EnqueueJob(ctx, EnqueueJobInput{Queue: q, Kind: "K", Payload: []byte(`{}`)})
+		require.NoError(t, err)
+
+		const maxAttempts = 3
+		// Simulate maxAttempts clean reschedules (quota exhaustion, ErrReschedule, etc.).
+		// Each cycle: claim (increments attempt_count) → reschedule (must reset attempt_count to 0).
+		for range maxAttempts {
+			claimed, err := store.ClaimJobs(ctx, q, 1)
+			require.NoError(t, err)
+			require.Len(t, claimed, 1)
+			// attempt_count was incremented by claim.
+			assert.Equal(t, 1, claimed[0].AttemptCount, "attempt_count should be 1 after each fresh claim")
+			// Clean reschedule: simulates handler returning ErrReschedule (quota reset, etc.).
+			require.NoError(t, store.RescheduleJob(ctx, job.ID, time.Now().UTC()))
+			after, err := store.GetJob(ctx, job.ID)
+			require.NoError(t, err)
+			assert.Equal(t, 0, after.AttemptCount, "RescheduleJob must reset attempt_count to 0")
+		}
+
+		// Now leave the job running (claim without completing) and sweep orphans.
+		claimed, err := store.ClaimJobs(ctx, q, 1)
+		require.NoError(t, err)
+		require.Len(t, claimed, 1)
+		// attempt_count is 1 (fresh claim after last reschedule reset it); < maxAttempts → must reset, not fail.
+		assert.Equal(t, 1, claimed[0].AttemptCount)
+		reset, failed, err := store.SweepOrphanedJobs(ctx, q, maxAttempts)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), reset, "job orphaned after clean reschedules must be reset, not failed")
+		assert.Equal(t, int64(0), failed, "job must NOT be permanently failed — it was never in a crash loop")
 	})
 
 	t.Run("request cancel and list in-flight with cancel flag", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Production \`media_index\` backlog and stalled new work were driven by two interacting bugs, not throughput alone:

1. **Claim vs concurrency mismatch** — \`ClaimJobs\` could mark up to \`batch_size\` rows as \`running\` on every poll while the \`pond\` worker pool only executed \`concurrency\` handlers. DB \`running\` counts could far exceed configured limits (e.g. batch=100, concurrency=2), inflating apparent load and starving dispatch.
2. **resvg SIGABRT crash loop** — SVGs with \`feDisplacementMap\` crash resvg at the C level (uncatchable by Go \`recover()\`). \`SweepOrphanedJobs\` reset all orphaned \`running\` jobs to \`pending\` with no attempt cap, so the same crash-inducing jobs looped forever and never reached terminal failure.

This PR adds claim backpressure tied to pool capacity and prevents resvg from handling crash-inducing SVGs, plus caps orphaned-job retries via \`attempt_count\`.

## Why It Matters

Issue #94 reported ~15k pending \`media_index\` jobs and new work appearing stuck. Without these fixes, crash loops keep jobs in \`running\`/\`pending\` indefinitely, orphan sweeps re-queue them forever, and inflated \`running\` counts make queue health misleading. Landing this stops process death on known-bad SVGs, terminates jobs cleanly after max attempts, and keeps claimed jobs aligned with actual worker capacity.

## Acceptance Checks

- [x] \`ClaimJobs\` is gated on \`min(pool_available, batch_size)\` — claimed rows never exceed configured concurrency or batch size
- [x] \`feDisplacementMap\` is the only hard-blocked filter primitive (confirmed SIGABRT trigger, linebender/resvg#1007/#1019/#1021); resvg is never invoked for SVGs containing it. \`feTurbulence\` and \`feComposite\` are browser-preferred but resvg-safe (degraded output, no crash); they fall back to resvg when no browser is available rather than silently skipping valid SVGs
- [x] SVGs with \`feDisplacementMap\` and no browser renderer are marked \`failed\` (not succeeded) with \`last_error\` set — operationally visible in the jobs table
- [x] \`attempt_count\` column added (migration \`020.sql\` + \`init_pg_db.sql\`); incremented atomically on claim, reset to 0 on clean reschedule; orphaned jobs with \`attempt_count >= maxAttempts\` are permanently failed instead of reset to pending
- [x] Unit tests updated/added for claim backpressure, attempt-cap sweep, rasterizer routing, and reschedule→sweep regression
- [x] \`make check\` passes locally
- [x] Manual verification: indexed Chaos Roads tokens (\`0x18Adc812…879E6:124/202/227/257\`) on full CGO build — no SIGABRT, container stayed healthy, failed jobs terminal at \`attempt_count=1\`

## Human Owner

_(fill in)_

## How The Agent Will Be Used

Agent implemented both fixes on branch \`fix/issue-94-media-queue-backlog\`, added migration/schema/tests, ran \`make check\`, rebuilt full CGO image locally, triggered token indexing for the Chaos Roads ERC721 tokens, and verified resvg bypass + clean job failure (no crash loop) in Docker logs and PostgreSQL job state.

## PR or Deploy Link

Fixes #94

### Known limitations

- SVGs routed to the browser renderer may still fail on chromedp timeout for heavy interactive HTML/SVG artworks (separate from the resvg crash loop; jobs fail cleanly rather than crashing the process).
- Production must apply migration \`020.sql\` before deploy.
- Full media processing requires CGO build (\`make build-full\` / \`CGO_ENABLED=1\`); lightweight builds stub the media worker.